### PR TITLE
debug:修复WebSocket数据不完整导致解析异常的问题

### DIFF
--- a/lib/network/handler.dart
+++ b/lib/network/handler.dart
@@ -329,11 +329,7 @@ class WebSocketChannelHandler extends ChannelHandler<Uint8List> {
   void channelRead(ChannelContext channelContext, Channel channel, Uint8List msg) {
     proxyChannel.write(msg);
     WebSocketFrame? frame;
-    try {
-      frame = decoder.decode(msg);
-    } catch (e) {
-      log.e("websocket decode error", error: e);
-    }
+    frame = decoder.decode(msg);
     if (frame == null) {
       return;
     }


### PR DESCRIPTION
在排查这个问题的时候
#316 
发现解析的WebSocket Frame大小不完整.  导致消息解析异常(类型和内容都不对)

解决方案:
新建一个成员变量buffer作为缓存.
先解析WebSocket的Header部分,从中提取出报文大小,待Frame完整以后再解析