### PR TITLE
Fix `pendingActivityIntent` not working

### DIFF
--- a/android/app/src/main/kotlin/com/network/proxy/ProxyVpnService.kt
+++ b/android/app/src/main/kotlin/com/network/proxy/ProxyVpnService.kt
@@ -153,6 +153,7 @@ class ProxyVpnService : VpnService(), ProtectSocket {
 
         val notification: Notification =
             NotificationCompat.Builder(this, VPN_NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
                 .setContentIntent(pendingActivityIntent)
                 .setContentTitle(getString(R.string.vpn_active_notification_title))
                 .setContentText(getString(R.string.vpn_active_notification_content))

--- a/lib/ui/mobile/setting/request_block.dart
+++ b/lib/ui/mobile/setting/request_block.dart
@@ -183,7 +183,7 @@ class RequestBlockAddDialog extends StatelessWidget {
                   SwitchWidget(title: localizations.enable, value: item.enabled, onChanged: (val) => enabled = val),
                   const SizedBox(height: 10),
                   TextFormField(
-                      initialValue: item.url.fixAutoLines(),
+                      initialValue: item.url,
                       maxLines: 3,
                       minLines: 1,
                       decoration: const InputDecoration(


### PR DESCRIPTION
修复点击通知没有跳转至App界面
移除textfield的`fixAutoLines`，否则每次编辑都会加入大量空白字符