### PR TITLE
Add option to manually copy certificate link to Safari

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -187,6 +187,8 @@
   "installRootCa": "Install Certificate",
   "installCaLocal": "Install Certificate to Local-Machine",
   "downloadRootCa": "Download Certificate",
+  "downloadRootCaNote": "Note: If you set the default browser to other than Safari, click this line to copy and paste the link to Safari browser",
+  "copyRootCaSuccess": "Copy link success",
   "generateCA": "Generate new root certificate",
   "generateCADescribe": "Are you sure you want to generate a new root certificate? If confirmed,\nYou need to reinstall and trust the new certificate",
   "resetDefaultCA": "Reset Default Root Certificate",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -188,6 +188,8 @@
   "installRootCa": "安装根证书",
   "installCaLocal": "安装根证书到本机",
   "downloadRootCa": "下载根证书",
+  "downloadRootCaNote": "注意：如果您将默认浏览器设置为 Safari 以外的浏览器，请单击此行复制并粘贴 Safari 浏览器的链接",
+  "copyRootCaSuccess": "复制链接成功",
   "generateCA": "重新生成根证书",
   "generateCADescribe": "您确定要生成新的根证书吗? 如果确认，\n则需要重新安装并信任新的证书",
   "resetDefaultCA": "重置默认根证书",

--- a/lib/ui/mobile/setting/ssl.dart
+++ b/lib/ui/mobile/setting/ssl.dart
@@ -26,6 +26,7 @@ import 'package:proxypin/network/util/logger.dart';
 import 'package:proxypin/ui/component/utils.dart';
 import 'package:proxypin/utils/lang.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/services.dart';
 
 class MobileSslWidget extends StatefulWidget {
   final ProxyServer proxyServer;
@@ -201,6 +202,7 @@ class _MobileSslState extends State<MobileSslWidget> {
             padding: const EdgeInsets.all(10),
             child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
               TextButton(onPressed: () => _downloadCert(), child: Text("1. ${localizations.downloadRootCa}")),
+              TextButton(onPressed: _copyProxyLink, child: Text(localizations.downloadRootCaNote)),
               TextButton(
                   onPressed: () {}, child: Text("2. ${localizations.installRootCa} -> ${localizations.trustCa}")),
               TextButton(onPressed: () {}, child: Text("2.1 ${localizations.installCaDescribe}")),
@@ -220,6 +222,19 @@ class _MobileSslState extends State<MobileSslWidget> {
     CertificateManager.cleanCache();
     await widget.proxyServer.retryBind();
     launchUrl(Uri.parse("http://127.0.0.1:${widget.proxyServer.port}/ssl"), mode: LaunchMode.externalApplication);
+  }
+
+  void _copyProxyLink() async {
+    CertificateManager.cleanCache();
+    await widget.proxyServer.retryBind();
+    var urlStr = Uri.parse("http://127.0.0.1:${widget.proxyServer.port}/ssl").toString();
+    print(urlStr);
+    Clipboard.setData(ClipboardData(text: urlStr)).then((_) {
+      if (!mounted) {
+        return;
+      }
+      FlutterToastr.show(localizations.copyRootCaSuccess, context);
+    });
   }
 
   void _exportFile(String name, {File? file, Uint8List? bytes}) async {

--- a/lib/ui/mobile/setting/ssl.dart
+++ b/lib/ui/mobile/setting/ssl.dart
@@ -228,7 +228,6 @@ class _MobileSslState extends State<MobileSslWidget> {
     CertificateManager.cleanCache();
     await widget.proxyServer.retryBind();
     var urlStr = Uri.parse("http://127.0.0.1:${widget.proxyServer.port}/ssl").toString();
-    print(urlStr);
     Clipboard.setData(ClipboardData(text: urlStr)).then((_) {
       if (!mounted) {
         return;


### PR DESCRIPTION
If the default browser of the iOS device is not Safari (eg: Edge or Chrome). It will open that browser and can't open the system pop-up to tell us to install the certificate

https://github.com/user-attachments/assets/3cefa836-863f-4090-9f39-108e191f6142

Add this option to allow and guide users to manually copy the download and paste the link to Safari in order to install the certificate

https://github.com/user-attachments/assets/feff231f-ffcf-489d-ab01-05b0a4a95a1b

