### PR TITLE
fix: URL encode report server name to support non-ASCII characters (#744)

### DIFF
--- a/lib/network/components/report_server_interceptor.dart
+++ b/lib/network/components/report_server_interceptor.dart
@@ -94,7 +94,9 @@ class ReportServerInterceptor extends Interceptor {
       // Set headers
       final matchedRule = server.name;
       if (matchedRule.isNotEmpty) {
-        ioReq.headers.set('X-Report-Name', matchedRule);
+        // URL encode the server name to support non-ASCII characters (e.g., Chinese)
+        final encodedName = Uri.encodeComponent(matchedRule);
+        ioReq.headers.set('X-Report-Name', encodedName);
       }
 
       ioReq.headers.set(HttpHeaders.contentTypeHeader, 'application/json; charset=utf-8');


### PR DESCRIPTION
修复解决了[issue #744](https://github.com/wanghongenpin/proxypin/issues/744)，当上报服务器名称包含中文等非 ASCII 字符时会导致 HTTP 头设置失败的问题