### PR TITLE
feat: 新增 WebSocket 推送服务，支持实时流量推送

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -377,5 +377,16 @@
 
   "local": "Local",
   "remoteUrl": "Remote URL",
-  "view": "View"
+  "view": "View",
+
+  "wsTrafficPush": "WebSocket Push",
+  "wsTrafficPushDescribe": "Push captured traffic to external tools via WebSocket in real-time",
+  "wsConnectedClients": "Connected Clients: {count}",
+  "@wsConnectedClients": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2195,6 +2195,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'View'**
   String get view;
+
+  /// No description provided for @wsTrafficPush.
+  ///
+  /// In en, this message translates to:
+  /// **'WebSocket Push'**
+  String get wsTrafficPush;
+
+  /// No description provided for @wsTrafficPushDescribe.
+  ///
+  /// In en, this message translates to:
+  /// **'Push captured traffic to external tools via WebSocket in real-time'**
+  String get wsTrafficPushDescribe;
+
+  /// No description provided for @wsConnectedClients.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected Clients: {count}'**
+  String wsConnectedClients(int count);
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1088,4 +1088,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get view => 'View';
+
+  @override
+  String get wsTrafficPush => 'WebSocket Push';
+
+  @override
+  String get wsTrafficPushDescribe => 'Push captured traffic to external tools via WebSocket in real-time';
+
+  @override
+  String wsConnectedClients(int count) {
+    return 'Connected Clients: $count';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1075,6 +1075,17 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get view => '查看';
+
+  @override
+  String get wsTrafficPush => 'WebSocket推送';
+
+  @override
+  String get wsTrafficPushDescribe => '通过WebSocket实时推送抓包流量到外部工具';
+
+  @override
+  String wsConnectedClients(int count) {
+    return '已连接客户端: $count';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -2146,4 +2157,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get view => '檢視';
+
+  @override
+  String get wsTrafficPush => 'WebSocket推送';
+
+  @override
+  String get wsTrafficPushDescribe => '通過WebSocket即時推送抓包流量到外部工具';
+
+  @override
+  String wsConnectedClients(int count) {
+    return '已連接用戶端: $count';
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -378,5 +378,9 @@
 
   "local": "本地",
   "remoteUrl": "远程URL",
-  "view": "查看"
+  "view": "查看",
+
+  "wsTrafficPush": "WebSocket推送",
+  "wsTrafficPushDescribe": "通过WebSocket实时推送抓包流量到外部工具",
+  "wsConnectedClients": "已连接客户端: {count}"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -353,5 +353,9 @@
 
   "local": "本地",
   "remoteUrl": "遠端URL",
-  "view": "檢視"
+  "view": "檢視",
+
+  "wsTrafficPush": "WebSocket推送",
+  "wsTrafficPushDescribe": "通過WebSocket即時推送抓包流量到外部工具",
+  "wsConnectedClients": "已連接用戶端: {count}"
 }

--- a/lib/network/bin/server.dart
+++ b/lib/network/bin/server.dart
@@ -24,6 +24,7 @@ import 'package:proxypin/network/components/report_server_interceptor.dart';
 import 'package:proxypin/network/components/request_block.dart';
 import 'package:proxypin/network/components/request_rewrite.dart';
 import 'package:proxypin/network/components/script.dart';
+import 'package:proxypin/network/components/ws_traffic_server.dart';
 import 'package:proxypin/network/handle/http_proxy_handle.dart';
 import 'package:proxypin/network/util/crts.dart';
 import 'package:proxypin/utils/platform.dart';
@@ -161,5 +162,23 @@ class ProxyServer {
   ///添加监听器
   void addListener(EventListener listener) {
     listeners.add(listener);
+  }
+
+  WsTrafficServer? _wsTrafficServer;
+
+  WsTrafficServer? get wsTrafficServer => _wsTrafficServer;
+
+  Future<void> startWsServer(int port) async {
+    if (_wsTrafficServer?.isRunning == true) return;
+    _wsTrafficServer = WsTrafficServer(port: port);
+    await _wsTrafficServer!.start();
+    listeners.add(_wsTrafficServer!);
+  }
+
+  Future<void> stopWsServer() async {
+    if (_wsTrafficServer == null) return;
+    listeners.remove(_wsTrafficServer!);
+    await _wsTrafficServer!.stop();
+    _wsTrafficServer = null;
   }
 }

--- a/lib/network/components/ws_traffic_server.dart
+++ b/lib/network/components/ws_traffic_server.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:proxypin/network/bin/listener.dart';
+import 'package:proxypin/network/channel/channel.dart';
+import 'package:proxypin/network/channel/channel_context.dart';
+import 'package:proxypin/network/http/http.dart';
+import 'package:proxypin/network/http/websocket.dart';
+import 'package:proxypin/network/util/logger.dart';
+import 'package:proxypin/utils/har.dart';
+
+class WsTrafficServer implements EventListener {
+  final int port;
+  HttpServer? _server;
+  final Set<WebSocket> _clients = {};
+
+  WsTrafficServer({this.port = 12080});
+
+  bool get isRunning => _server != null;
+
+  int get clientCount => _clients.length;
+
+  Future<void> start() async {
+    if (_server != null) return;
+    _server = await HttpServer.bind('127.0.0.1', port);
+    _server!.listen((req) async {
+      if (WebSocketTransformer.isUpgradeRequest(req)) {
+        final ws = await WebSocketTransformer.upgrade(req);
+        _clients.add(ws);
+        logger.i('WS traffic client connected, total: ${_clients.length}');
+        ws.listen(null,
+            onDone: () => _clients.remove(ws),
+            onError: (_) => _clients.remove(ws));
+      } else {
+        req.response.statusCode = 403;
+        req.response.close();
+      }
+    });
+    logger.i('WS traffic server started on port $port');
+  }
+
+  Future<void> stop() async {
+    for (final ws in Set.of(_clients)) {
+      try {
+        await ws.close();
+      } catch (_) {}
+    }
+    _clients.clear();
+    await _server?.close(force: true);
+    _server = null;
+    logger.i('WS traffic server stopped');
+  }
+
+  void _broadcast(Map msg) {
+    if (_clients.isEmpty) return;
+    final data = jsonEncode(msg);
+    for (final ws in Set.of(_clients)) {
+      try {
+        ws.add(data);
+      } catch (_) {
+        _clients.remove(ws);
+      }
+    }
+  }
+
+  @override
+  void onRequest(Channel channel, HttpRequest request) {
+    _broadcast({
+      'type': 'request',
+      'id': request.requestId,
+      'data': {
+        'method': request.method.name,
+        'uri': request.requestUrl,
+        'headers': request.headers.toJson(),
+        'body': request.bodyAsString,
+        'requestTime': request.requestTime.millisecondsSinceEpoch,
+      },
+    });
+  }
+
+  @override
+  void onResponse(ChannelContext channelContext, HttpResponse response) {
+    final req = response.request;
+    if (req == null) return;
+    _broadcast({
+      'type': 'response',
+      'id': req.requestId,
+      'data': Har.toHar(req),
+    });
+  }
+
+  @override
+  void onMessage(Channel channel, HttpMessage message, WebSocketFrame frame) {
+    _broadcast({
+      'type': 'ws_message',
+      'id': message.requestId,
+      'data': {
+        'opcode': frame.opcode,
+        'isFromClient': frame.isFromClient,
+        'payloadLength': frame.payloadLength,
+        'text': frame.payloadDataAsString,
+        'time': frame.time.millisecondsSinceEpoch,
+      },
+    });
+  }
+}

--- a/lib/ui/configuration.dart
+++ b/lib/ui/configuration.dart
@@ -94,6 +94,10 @@ class AppConfiguration {
   ///自动已读
   bool autoReadEnabled = true;
 
+  /// WebSocket 推送服务
+  bool wsServerEnabled = false;
+  int wsServerPort = 12080;
+
   //桌面window大小
   Size? windowSize;
 
@@ -213,6 +217,8 @@ class AppConfiguration {
       bottomNavigation = config['bottomNavigation'] ?? true;
       memoryCleanupThreshold = config['memoryCleanupThreshold'];
       autoReadEnabled = config['autoReadEnabled'] ?? true;
+      wsServerEnabled = config['wsServerEnabled'] ?? false;
+      wsServerPort = config['wsServerPort'] ?? 12080;
 
       windowSize =
           config['windowSize'] == null ? null : Size(config['windowSize']['width'], config['windowSize']['height']);
@@ -257,6 +263,8 @@ class AppConfiguration {
       "headerExpanded": headerExpanded,
       "headerViewMode": headerViewMode,
       "autoReadEnabled": autoReadEnabled,
+      "wsServerEnabled": wsServerEnabled,
+      "wsServerPort": wsServerPort,
       if (memoryCleanupThreshold != null) 'memoryCleanupThreshold': memoryCleanupThreshold,
       if (Platforms.isMobile()) 'pipEnabled': pipEnabled.value,
       if (Platforms.isMobile()) 'pipIcon': pipIcon.value ? true : null,

--- a/lib/ui/desktop/setting/setting.dart
+++ b/lib/ui/desktop/setting/setting.dart
@@ -23,6 +23,7 @@ import 'package:proxypin/network/util/system_proxy.dart';
 import 'package:proxypin/ui/component/multi_window.dart';
 import 'package:proxypin/ui/component/proxy_port_setting.dart';
 import 'package:proxypin/ui/component/widgets.dart';
+import 'package:proxypin/ui/configuration.dart';
 import 'package:proxypin/ui/desktop/setting/about.dart';
 import 'package:proxypin/ui/desktop/setting/external_proxy.dart';
 import 'package:proxypin/ui/desktop/setting/hosts.dart';
@@ -80,6 +81,7 @@ class _SettingState extends State<Setting> {
             onPressed: () => MultiWindow.openWindow(localizations.script, 'ScriptWidget', size: const Size(800, 780))),
         item(localizations.breakpoint, onPressed: requestBreakpoint),
         item(localizations.externalProxy, onPressed: setExternalProxy),
+        item(localizations.wsTrafficPush, onPressed: showWsServerSetting),
         item(localizations.about, onPressed: showAbout),
       ],
     );
@@ -148,6 +150,114 @@ class _SettingState extends State<Setting> {
 
   void showRequestCrypto() {
     MultiWindow.openWindow(localizations.requestCrypto, 'RequestCryptoPage', size: const Size(820, 750));
+  }
+
+  void showWsServerSetting() {
+    showDialog(
+        barrierDismissible: false,
+        context: context,
+        builder: (context) => WsServerDialog(proxyServer: widget.proxyServer));
+  }
+}
+
+class WsServerDialog extends StatefulWidget {
+  final ProxyServer proxyServer;
+
+  const WsServerDialog({super.key, required this.proxyServer});
+
+  @override
+  State<WsServerDialog> createState() => _WsServerDialogState();
+}
+
+class _WsServerDialogState extends State<WsServerDialog> {
+  late bool enabled;
+  late TextEditingController portController;
+  AppConfiguration? appConfig;
+
+  @override
+  void initState() {
+    super.initState();
+    enabled = widget.proxyServer.wsTrafficServer?.isRunning ?? false;
+    portController = TextEditingController();
+    AppConfiguration.instance.then((config) {
+      if (!mounted) return;
+      setState(() {
+        appConfig = config;
+        enabled = config.wsServerEnabled;
+        portController.text = config.wsServerPort.toString();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    portController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    int clientCount = widget.proxyServer.wsTrafficServer?.clientCount ?? 0;
+
+    return AlertDialog(
+      scrollable: true,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10.0)),
+      title: Text(AppLocalizations.of(context)!.wsTrafficPush, style: const TextStyle(fontSize: 15)),
+      content: SizedBox(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(children: [
+              Expanded(child: Text(AppLocalizations.of(context)!.enable, style: const TextStyle(fontSize: 14))),
+              SwitchWidget(
+                  value: enabled,
+                  scale: 0.85,
+                  onChanged: (val) async {
+                    int port = int.tryParse(portController.text) ?? 12080;
+                    if (val) {
+                      await widget.proxyServer.startWsServer(port);
+                    } else {
+                      await widget.proxyServer.stopWsServer();
+                    }
+                    appConfig?.wsServerEnabled = val;
+                    appConfig?.wsServerPort = port;
+                    appConfig?.flushConfig();
+                    setState(() => enabled = val);
+                  }),
+            ]),
+            const SizedBox(height: 12),
+            Row(children: [
+              Text(AppLocalizations.of(context)!.port, style: const TextStyle(fontSize: 14)),
+              const SizedBox(width: 20),
+              SizedBox(
+                  width: 100,
+                  child: TextField(
+                    controller: portController,
+                    enabled: !enabled,
+                    style: const TextStyle(fontSize: 14),
+                    decoration: const InputDecoration(
+                        contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                        border: OutlineInputBorder(),
+                        isDense: true),
+                  )),
+            ]),
+            const SizedBox(height: 16),
+            Text('ws://127.0.0.1:${portController.text}',
+                style: TextStyle(fontSize: 13, color: Colors.grey.shade600)),
+            const SizedBox(height: 8),
+            Text(AppLocalizations.of(context)!.wsConnectedClients(clientCount),
+                style: TextStyle(fontSize: 13, color: Colors.grey.shade600)),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(AppLocalizations.of(context)!.close)),
+      ],
+    );
   }
 }
 

--- a/lib/ui/launch/launch.dart
+++ b/lib/ui/launch/launch.dart
@@ -25,6 +25,7 @@ import 'package:proxypin/network/bin/server.dart';
 import 'package:proxypin/network/util/logger.dart';
 import 'package:proxypin/ui/desktop/ssl/pc_cert.dart';
 import 'package:proxypin/utils/lang.dart';
+import 'package:proxypin/ui/configuration.dart';
 import 'package:proxypin/utils/platform.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -187,11 +188,17 @@ class _SocketLaunchState extends State<SocketLaunch> with WindowListener, Widget
         return;
       }
 
-      widget.proxyServer.start().then((value) {
+      widget.proxyServer.start().then((value) async {
         setState(() {
           started = true;
         });
         widget.onStart?.call();
+        if (Platforms.isDesktop()) {
+          var appConfig = await AppConfiguration.instance;
+          if (appConfig.wsServerEnabled) {
+            widget.proxyServer.startWsServer(appConfig.wsServerPort);
+          }
+        }
       }).catchError((e) {
         logger.e("启动代理服务器失败", error: e);
         String message = localizations.proxyPortRepeat(widget.proxyServer.port);


### PR DESCRIPTION
## 概述

为 ProxyPin 桌面端新增内置 WebSocket 推送服务，让外部工具（AI 助手、MCP 服务器、自定义脚本）能够实时接收抓包的 HTTP(S)/WebSocket/SSE 流量数据。

### 架构

```
ProxyPin 应用 (WS :12080) → 外部工具（如 Claude Code 通过 MCP 接入）
```

- **WsTrafficServer** 实现 `EventListener` 接口，将每条请求/响应/WS帧以 JSON 广播给所有已连接的 WebSocket 客户端
- 生命周期独立于 ProxyServer 的 start/stop/restart，不会出现重复注册监听器的问题
- 仅监听 `127.0.0.1`（本地回环），不对外暴露
- 响应体自动解码（gzip/br/deflate 由 `bodyAsString` / `Har.toHar()` 处理）
- 仅桌面端功能，不影响移动端转发

### 消息协议

| 类型 | 触发时机 | 格式 |
|------|---------|------|
| `request` | 请求到达代理时 | method、url、headers、已解码的 body |
| `response` | 响应完成时 | 完整 HAR entry（请求 + 响应） |
| `ws_message` | WebSocket/SSE 帧 | opcode、文本内容、方向、时间戳 |

### 设置界面

设置菜单 → **WebSocket推送**：
- 启用/禁用开关
- 端口配置（默认：12080）
- 已连接客户端数量显示
- 地址提示：`ws://127.0.0.1:{port}`

### 配套 MCP 服务器

配套 npm 包 [`proxypin-mcp`](https://github.com/k186/proxypin-mcp) 连接此 WebSocket 服务器，将流量数据以 MCP 工具的形式暴露给 AI 按需查询（列表、搜索、查看请求详情）。

### 修改文件

- **新增：** `lib/network/components/ws_traffic_server.dart`
- **修改：** `server.dart`（startWsServer/stopWsServer）、`configuration.dart`、`setting.dart`、`launch.dart`
- **国际化：** en、zh、zh_Hant

## 测试计划

- [ ] 在设置中开启 WebSocket推送，验证 `ws://127.0.0.1:12080` 可以接受连接
- [ ] 通过代理浏览网页，验证 WS 客户端收到 `request` + `response` 消息
- [ ] 关闭开关，验证 WS 连接断开且不再发送消息
- [ ] 代理重启后不会出现重复广播
- [ ] 移动端转发到桌面端的功能不受影响