### PR TITLE
fix(mobile): preserve tab index and scroll position when returning fr…

### DIFF
--- a/lib/ui/component/utils.dart
+++ b/lib/ui/component/utils.dart
@@ -230,7 +230,10 @@ class _FutureWidgetState<T> extends State<_FutureWidget<T>> {
   void didUpdateWidget(covariant _FutureWidget<T> old) {
     super.didUpdateWidget(old);
     if (old.future != widget.future || old.initialData != widget.initialData) {
-      _data = widget.initialData;
+      // 仅当 initialData 变化或还没有数据时才重置，避免已加载的 widget 树被不必要地销毁重建
+      if (widget.initialData != null || _data == null) {
+        _data = widget.initialData;
+      }
       _subscribe();
     }
   }

--- a/lib/ui/mobile/request/history.dart
+++ b/lib/ui/mobile/request/history.dart
@@ -418,8 +418,15 @@ class _HistoryRecordState extends State<HistoryRecord> {
   final GlobalKey<MobileSearchState> searchStateKey = GlobalKey<MobileSearchState>();
 
   var searchEnabled = ValueNotifier(false);
+  late final Future<List<HttpRequest>> _requestsFuture;
 
   AppLocalizations get localizations => AppLocalizations.of(context)!;
+
+  @override
+  void initState() {
+    super.initState();
+    _requestsFuture = HistoryStorage.instance.then((storage) => storage.getRequests(widget.history));
+  }
 
   @override
   void dispose() {
@@ -475,9 +482,7 @@ class _HistoryRecordState extends State<HistoryRecord> {
                     }),
               ],
             )),
-        body: futureWidget(
-            loading: true,
-            HistoryStorage.instance.then((storage) => storage.getRequests(widget.history)),
+        body: futureWidget(loading: true, _requestsFuture,
             (data) =>
                 RequestListWidget(proxyServer: widget.proxyServer, list: ListenableList(data), key: requestStateKey)));
   }

--- a/lib/ui/mobile/request/list.dart
+++ b/lib/ui/mobile/request/list.dart
@@ -97,7 +97,7 @@ class RequestListState extends State<RequestListWidget> with SingleTickerProvide
                   key: domainListKey, list: container, proxyServer: widget.proxyServer, onRemove: domainListRemove),
             ],
           ),
-        ));
+        );
   }
 
   ///添加请求

--- a/lib/ui/mobile/request/list.dart
+++ b/lib/ui/mobile/request/list.dart
@@ -46,18 +46,21 @@ class RequestListWidget extends StatefulWidget {
   }
 }
 
-class RequestListState extends State<RequestListWidget> {
+class RequestListState extends State<RequestListWidget> with SingleTickerProviderStateMixin {
   final GlobalKey<RequestSequenceState> requestSequenceKey = GlobalKey<RequestSequenceState>();
   final GlobalKey<DomainListState> domainListKey = GlobalKey<DomainListState>();
 
   //请求列表容器
   ListenableList<HttpRequest> container = ListenableList();
 
+  late TabController _tabController;
+
   AppLocalizations get localizations => AppLocalizations.of(context)!;
 
   @override
   void initState() {
     super.initState();
+    _tabController = TabController(length: 2, vsync: this);
     if (widget.list != null) {
       container = widget.list!;
     }
@@ -65,6 +68,7 @@ class RequestListState extends State<RequestListWidget> {
 
   @override
   void dispose() {
+    _tabController.dispose();
     RequestRowState.removeAutoReadByIds(container.map((request) => request.requestId));
     super.dispose();
   }
@@ -79,14 +83,11 @@ class RequestListState extends State<RequestListWidget> {
       DoubleClickHandle(handle: () => domainListKey.currentState?.scrollToTop())
     ];
 
-    return DefaultTabController(
-        length: tabs.length,
-        child: Scaffold(
+    return Scaffold(
           appBar: AppBar(
-              title: TabBar(tabs: tabs, onTap: (index) => tabClickHandles[index].call()),
+              title: TabBar(tabs: tabs, controller: _tabController, onTap: (index) => tabClickHandles[index].call()),
               automaticallyImplyLeading: false),
-          body: TabBarView(
-            children: [
+          body: TabBarView(controller: _tabController, children: [
               RequestSequence(
                   key: requestSequenceKey,
                   container: container,

--- a/lib/ui/mobile/request/request_sequence.dart
+++ b/lib/ui/mobile/request/request_sequence.dart
@@ -48,6 +48,8 @@ class RequestSequenceState extends State<RequestSequence> with AutomaticKeepAliv
   //关键词高亮监听
   late VoidCallback highlightListener;
 
+  final ScrollController _scrollController = ScrollController();
+
   @override
  void initState() {
     super.initState();
@@ -65,6 +67,7 @@ class RequestSequenceState extends State<RequestSequence> with AutomaticKeepAliv
   @override
   void dispose() {
     KeywordHighlights.removeListener(highlightListener);
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -156,9 +159,9 @@ class RequestSequenceState extends State<RequestSequence> with AutomaticKeepAliv
     super.build(context);
 
     return Scrollbar(
-        controller: PrimaryScrollController.maybeOf(context),
+        controller: _scrollController,
         child: ListView.separated(
-            controller: PrimaryScrollController.maybeOf(context),
+            controller: _scrollController,
             cacheExtent: 1000,
             separatorBuilder: (context, index) =>
                 Divider(thickness: 0.2, height: 0, color: Theme.of(context).dividerColor),
@@ -186,8 +189,7 @@ class RequestSequenceState extends State<RequestSequence> with AutomaticKeepAliv
   }
 
   scrollToTop() {
-    PrimaryScrollController.maybeOf(context)
-        ?.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.ease);
+    _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.ease);
   }
 
   ///排序


### PR DESCRIPTION
从抓包记录里点到抓包详情,返回的时候目前会丢失当前滚动位置和当前tab(全部请求/域名列表),每次返回都会回到第一个