### PR TITLE
fix(script): preserve original request when onRequest leaves it unchanged

### DIFF
--- a/lib/network/components/js/script_engine.dart
+++ b/lib/network/components/js/script_engine.dart
@@ -155,16 +155,32 @@ class JavaScriptEngine {
     };
   }
 
-  /// 脚本是否未修改请求：返回对象去掉 scriptContext 后与原始序列化逐字节一致即视为未改动。
+  /// 脚本是否未修改请求：返回对象去掉 scriptContext 后与原始请求结构一致即视为未改动。
   /// 用于在脚本未真正改动请求时跳过 convertHttpRequest 的有损重建（避免 query 重编码/header 重排破坏签名）。
-  static bool isRequestUnchanged(String originalRequestJson, dynamic result) {
+  /// 直接复用 runScript 已构建的请求 Map 做结构化深比较，无需再次序列化。
+  static bool isRequestUnchanged(Map<dynamic, dynamic> originalRequest, dynamic result) {
     if (result is! Map) return false;
-    try {
-      final copy = Map<dynamic, dynamic>.of(result)..remove('scriptContext');
-      return jsonEncode(copy) == originalRequestJson;
-    } catch (_) {
-      return false;
+    final copy = Map<dynamic, dynamic>.of(result)..remove('scriptContext');
+    return _deepEquals(copy, originalRequest);
+  }
+
+  static bool _deepEquals(dynamic a, dynamic b) {
+    if (identical(a, b)) return true;
+    if (a is Map && b is Map) {
+      if (a.length != b.length) return false;
+      for (final key in a.keys) {
+        if (!b.containsKey(key) || !_deepEquals(a[key], b[key])) return false;
+      }
+      return true;
     }
+    if (a is List && b is List) {
+      if (a.length != b.length) return false;
+      for (var i = 0; i < a.length; i++) {
+        if (!_deepEquals(a[i], b[i])) return false;
+      }
+      return true;
+    }
+    return a == b;
   }
 
   //转换js response

--- a/lib/network/components/js/script_engine.dart
+++ b/lib/network/components/js/script_engine.dart
@@ -155,6 +155,18 @@ class JavaScriptEngine {
     };
   }
 
+  /// 脚本是否未修改请求：返回对象去掉 scriptContext 后与原始序列化逐字节一致即视为未改动。
+  /// 用于在脚本未真正改动请求时跳过 convertHttpRequest 的有损重建（避免 query 重编码/header 重排破坏签名）。
+  static bool isRequestUnchanged(String originalRequestJson, dynamic result) {
+    if (result is! Map) return false;
+    try {
+      final copy = Map<dynamic, dynamic>.of(result)..remove('scriptContext');
+      return jsonEncode(copy) == originalRequestJson;
+    } catch (_) {
+      return false;
+    }
+  }
+
   //转换js response
   static Future<Map<String, dynamic>> convertJsResponse(HttpResponse response) async {
     dynamic body = await response.decodeBodyString();

--- a/lib/network/components/manager/script_manager.dart
+++ b/lib/network/components/manager/script_manager.dart
@@ -290,7 +290,10 @@ async function onResponse(context, request, response) {
         }
         request.attributes['scriptContext'] = result['scriptContext'];
         scriptSession = result['scriptContext']['session'] ?? {};
-        request = JavaScriptEngine.convertHttpRequest(request, result);
+        // 脚本未改动请求时保留原始字节，避免 query 重编码/header 重排破坏签名
+        if (!JavaScriptEngine.isRequestUnchanged(jsRequest, result)) {
+          request = JavaScriptEngine.convertHttpRequest(request, result);
+        }
       }
     }
     return request;

--- a/lib/network/components/manager/script_manager.dart
+++ b/lib/network/components/manager/script_manager.dart
@@ -274,7 +274,8 @@ async function onResponse(context, request, response) {
     for (var item in list) {
       if (item.enabled && item.match(url)) {
         var context = jsonEncode(scriptContext(item));
-        var jsRequest = jsonEncode(await JavaScriptEngine.convertJsRequest(request));
+        var jsRequestMap = await JavaScriptEngine.convertJsRequest(request);
+        var jsRequest = jsonEncode(jsRequestMap);
         String? script = await getScript(item);
         if (script == null) {
           continue;
@@ -291,7 +292,7 @@ async function onResponse(context, request, response) {
         request.attributes['scriptContext'] = result['scriptContext'];
         scriptSession = result['scriptContext']['session'] ?? {};
         // 脚本未改动请求时保留原始字节，避免 query 重编码/header 重排破坏签名
-        if (!JavaScriptEngine.isRequestUnchanged(jsRequest, result)) {
+        if (!JavaScriptEngine.isRequestUnchanged(jsRequestMap, result)) {
           request = JavaScriptEngine.convertHttpRequest(request, result);
         }
       }


### PR DESCRIPTION
## 问题

当脚本的 `onRequest` 原样返回请求（典型如仅用于抓包/统计、并不修改请求的脚本）时，`ScriptManager.runScript` 仍会无条件调用 `JavaScriptEngine.convertHttpRequest` 对请求进行「拆解—重建」。

重建过程中，query 经历了一次有损往返：

- `convertJsRequest` 通过 `requestUri.queryParameters` 把 query 解码成 Map；
- `UriUtils.mapToQuery` 再用 `Uri.encodeComponent` 重新编码。

这条往返并非字节无损。例如原始 query 中的 `/`、`+` 等字符重编码后会变成 `%2F` 等，使最终发往服务器的 query 字符串与客户端原始发送的字节不一致；同时 `request.headers.clear()` 后重新写入也会改变 header 的顺序与大小写。

对于「请求签名基于原始 query 字符串 / header 计算」的接口，上述改动会导致服务端签名校验失败而拒绝请求——即便脚本本意并未修改任何内容。表现为：开启一个什么都不改的脚本后，部分接口返回异常、数据为空、客户端反复重试。

## 修改

仅当脚本确实修改了请求时才执行重建；若脚本返回的请求与输入逐字节一致（仅多出 `scriptContext`），则跳过 `convertHttpRequest`，保留原始请求字节原样转发。

- 新增 `JavaScriptEngine.isRequestUnchanged`：将返回对象去掉 `scriptContext` 后与原始序列化字符串比较。
- `runScript` 中条件化调用 `convertHttpRequest`。

判定可靠性：`convertJsRequest` 生成的字段顺序固定，嵌入 JS 后 `scriptContext` 始终最后追加，去除后序列化顺序与原始请求一致；判定异常时回退到原有重建逻辑，不引入回归。

## 影响范围

- 不修改请求的脚本：行为修正（不再破坏请求），并顺带省去一次不必要的重建开销。
- 修改请求的脚本：行为完全不变，仍走原有 `convertHttpRequest`。
- 仅作用于请求侧（`onRequest`），不触碰响应处理逻辑。