### PR TITLE
Fix Floating Window not showing up always on back press in android

### DIFF
--- a/lib/utils/navigator.dart
+++ b/lib/utils/navigator.dart
@@ -37,16 +37,16 @@ class NavigatorHelper {
 NavigatorHelper navigatorHelper = NavigatorHelper();
 
 class NavigatorPage extends StatelessWidget {
-  final GlobalKey navigatorKey;
+  final GlobalKey<NavigatorState> navigatorKey;
   final Widget child;
 
   const NavigatorPage({super.key, required this.child, required this.navigatorKey});
 
   bool onPopInvoked() {
-    var context = navigatorKey.currentState?.context;
-    if (context == null) return false;
-    if (Navigator.canPop(context)) {
-      Navigator.maybePop(context);
+    var state = navigatorKey.currentState;
+    if (state == null) return false;
+    if (state.canPop()) {
+      state.maybePop();
       return true;
     }
     return false;


### PR DESCRIPTION
The Context Resolution Flaw: In the old code, navigatorKey.currentState?.context evaluated to the BuildContext of the Navigator widget itself. When calling Navigator.canPop(context), Flutter looked upwards from that node in the widget tree, completely skipping the inner tab's history stack and querying the Root Navigator. Since the root layout could not pop, it returned false, bypassing your interception logic and letting Android close the app.

Direct State Target: The new code talks directly to the target NavigatorState via the global key. Calling state.canPop() explicitly checks that isolated tab's internal history stack array without looking up the widget tree. If a nested sub-page is open, it returns true and pops it cleanly, successfully signaling to the root container that the back gesture was handled internally.