### PR TITLE
fix: preserve remaining WebSocket frames when multiple frames arrive in a single TCP segment

### DIFF
--- a/lib/network/handle/websocket_handle.dart
+++ b/lib/network/handle/websocket_handle.dart
@@ -18,20 +18,33 @@ class WebSocketChannelHandler extends ChannelHandler<Uint8List> {
   @override
   Future<void> channelRead(ChannelContext channelContext, Channel channel, Uint8List msg) async {
     proxyChannel.writeBytes(msg);
-    WebSocketFrame? frame;
-    try {
-      frame = decoder.decode(msg);
-    } catch (e, stackTrace) {
-      log.e("websocket decode error", error: e, stackTrace: stackTrace);
-    }
-    if (frame == null) {
-      return;
-    }
-    frame.isFromClient = message is HttpRequest;
 
-    message.messages.add(frame);
-    channelContext.listener?.onMessage(channel, message, frame);
-    logger.d(
-        "[${channelContext.clientChannel?.id}] websocket channelRead ${frame.payloadLength} ${frame.fin} ${frame.payloadDataAsString}");
+    // A single TCP read may carry multiple WebSocket frames (Nagle, TLS record
+    // batching, OS coalescing). Drain the decoder until no more full frames
+    // remain in its buffer; subsequent iterations pass empty bytes so we only
+    // consume what is already buffered.
+    Uint8List chunk = msg;
+    while (true) {
+      WebSocketFrame? frame;
+      try {
+        frame = decoder.decode(chunk);
+      } catch (e, stackTrace) {
+        log.e("websocket decode error", error: e, stackTrace: stackTrace);
+        break;
+      }
+      if (frame == null) {
+        break;
+      }
+      frame.isFromClient = message is HttpRequest;
+
+      message.messages.add(frame);
+      channelContext.listener?.onMessage(channel, message, frame);
+      logger.d(
+          "[${channelContext.clientChannel?.id}] websocket channelRead ${frame.payloadLength} ${frame.fin} ${frame.payloadDataAsString}");
+
+      chunk = _empty;
+    }
   }
+
+  static final Uint8List _empty = Uint8List(0);
 }

--- a/lib/network/http/websocket.dart
+++ b/lib/network/http/websocket.dart
@@ -108,13 +108,14 @@ class WebSocketDecoder {
 
   WebSocketFrame? decode(Uint8List newData) {
     buffer.putBytes(newData);
-    if (!canParseWebSocketFrame(buffer.bytes)) {
+    int? frameLen = _tryFrameLength(buffer.bytes);
+    if (frameLen == null) {
       return null;
     }
 
     try {
       WebSocketFrame frame = _parseWebSocketFrame(buffer.bytes);
-      buffer.clear();
+      buffer.removeBytes(frameLen);
       return frame;
     } catch (e, stackTrace) {
       logger.e("WebSocket decode error", error: e, stackTrace: stackTrace);
@@ -122,16 +123,18 @@ class WebSocketDecoder {
     }
   }
 
-  bool canParseWebSocketFrame(Uint8List data) {
+  /// Returns the total byte length of the next frame in [data], or null if
+  /// the data is incomplete or contains an invalid opcode.
+  int? _tryFrameLength(Uint8List data) {
     if (data.length < 2) {
-      return false;
+      return null;
     }
 
     var reader = ByteData.sublistView(data);
 
     var opcode = reader.getUint8(0) & 0x0f;
     if (opcode > 0xA) {
-      return false;
+      return null;
     }
 
     var mask = reader.getUint8(1) >> 7;
@@ -139,27 +142,27 @@ class WebSocketDecoder {
     int payloadLength = reader.getUint8(1) & 0x7f;
 
     if (payloadLength == 126) {
-      if (data.length < 4) return false;
+      if (data.length < 4) return null;
       payloadLength = reader.getUint16(2);
       payloadStart += 2;
     } else if (payloadLength == 127) {
-      if (data.length < 10) return false;
+      if (data.length < 10) return null;
       payloadLength = reader.getUint64(2);
       payloadStart += 8;
     }
 
     if (mask == 1) {
       if (data.length < payloadStart + 4) {
-        return false;
+        return null;
       }
       payloadStart += 4;
     }
 
     if (data.length < payloadStart + payloadLength) {
-      return false;
+      return null;
     }
 
-    return true;
+    return payloadStart + payloadLength;
   }
 
   WebSocketFrame _parseWebSocketFrame(Uint8List data) {
@@ -254,5 +257,13 @@ class ByteBuffer {
 
   void clear() {
     _bytes = Uint8List(0);
+  }
+
+  void removeBytes(int count) {
+    if (count >= _bytes.length) {
+      _bytes = Uint8List(0);
+    } else {
+      _bytes = _bytes.sublist(count);
+    }
   }
 }

--- a/test/websocket_decoder_test.dart
+++ b/test/websocket_decoder_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:proxypin/network/http/websocket.dart';
+
+/// Builds an unmasked (server-to-client) text frame. FIN=1, opcode=0x01.
+Uint8List _textFrame(String text) {
+  final payload = utf8.encode(text);
+  final builder = BytesBuilder();
+  builder.addByte(0x80 | 0x01); // FIN + text
+  if (payload.length < 126) {
+    builder.addByte(payload.length);
+  } else if (payload.length <= 0xFFFF) {
+    builder.addByte(126);
+    builder.addByte((payload.length >> 8) & 0xff);
+    builder.addByte(payload.length & 0xff);
+  } else {
+    builder.addByte(127);
+    final len = payload.length;
+    for (var i = 7; i >= 0; i--) {
+      builder.addByte((len >> (i * 8)) & 0xff);
+    }
+  }
+  builder.add(payload);
+  return builder.toBytes();
+}
+
+void main() {
+  final empty = Uint8List(0);
+
+  test('decode returns single frame when only one frame is in the buffer', () {
+    final decoder = WebSocketDecoder();
+    final frame = decoder.decode(_textFrame('hello'));
+    expect(frame, isNotNull);
+    expect(frame!.payloadDataAsString, 'hello');
+
+    // Buffer should be empty; a follow-up call with no new data returns null.
+    expect(decoder.decode(empty), isNull);
+  });
+
+  test('decode preserves remaining frames when multiple arrive in one read', () {
+    final decoder = WebSocketDecoder();
+    final combined = BytesBuilder()
+      ..add(_textFrame('hello'))
+      ..add(_textFrame('world'))
+      ..add(_textFrame('!'));
+
+    final first = decoder.decode(combined.toBytes());
+    expect(first, isNotNull);
+    expect(first!.payloadDataAsString, 'hello');
+
+    // Subsequent frames must be drainable from the buffer without new bytes.
+    final second = decoder.decode(empty);
+    expect(second, isNotNull);
+    expect(second!.payloadDataAsString, 'world');
+
+    final third = decoder.decode(empty);
+    expect(third, isNotNull);
+    expect(third!.payloadDataAsString, '!');
+
+    // Buffer is now empty.
+    expect(decoder.decode(empty), isNull);
+  });
+
+  test('decode returns null while a frame is split across reads, then completes it', () {
+    final decoder = WebSocketDecoder();
+    final full = _textFrame('hello world');
+    final firstHalf = Uint8List.sublistView(full, 0, 4);
+    final secondHalf = Uint8List.sublistView(full, 4);
+
+    expect(decoder.decode(firstHalf), isNull);
+    final frame = decoder.decode(secondHalf);
+    expect(frame, isNotNull);
+    expect(frame!.payloadDataAsString, 'hello world');
+    expect(decoder.decode(empty), isNull);
+  });
+
+  test('decode drains frames that straddle read boundaries', () {
+    final decoder = WebSocketDecoder();
+    final a = _textFrame('alpha');
+    final b = _textFrame('beta');
+
+    // First read: all of frame A + first byte of frame B.
+    final part1 = BytesBuilder()
+      ..add(a)
+      ..addByte(b[0]);
+    final firstDecoded = decoder.decode(part1.toBytes());
+    expect(firstDecoded, isNotNull);
+    expect(firstDecoded!.payloadDataAsString, 'alpha');
+
+    // Draining with empty bytes should not produce another frame yet — frame B
+    // is incomplete.
+    expect(decoder.decode(empty), isNull);
+
+    // Second read: rest of frame B.
+    final part2 = Uint8List.sublistView(b, 1);
+    final secondDecoded = decoder.decode(part2);
+    expect(secondDecoded, isNotNull);
+    expect(secondDecoded!.payloadDataAsString, 'beta');
+    expect(decoder.decode(empty), isNull);
+  });
+
+  test('decode handles 16-bit extended payload length frames back-to-back', () {
+    final decoder = WebSocketDecoder();
+    final big = 'x' * 200; // triggers 16-bit length header
+    final combined = BytesBuilder()
+      ..add(_textFrame(big))
+      ..add(_textFrame('tail'));
+
+    final first = decoder.decode(combined.toBytes());
+    expect(first, isNotNull);
+    expect(first!.payloadLength, 200);
+    expect(first.payloadDataAsString, big);
+
+    final second = decoder.decode(empty);
+    expect(second, isNotNull);
+    expect(second!.payloadDataAsString, 'tail');
+    expect(decoder.decode(empty), isNull);
+  });
+}


### PR DESCRIPTION
## Problem

`WebSocketDecoder.decode()` calls `buffer.clear()` after parsing the first frame, which discards any additional frames that arrived in the same TCP read.

This happens frequently because:
- **TCP Nagle algorithm** batches small packets into larger segments
- **TLS record batching** wraps multiple WebSocket frames into one TLS record
- **OS network stack** may coalesce multiple frames into a single read() call

**Result**: WebSocket capture only shows the first message per TCP segment. All subsequent messages in the same segment are silently dropped.

## Example

```
Server sends 3 WebSocket frames in one TCP segment:
  [frame1: "hello"] [frame2: "world"] [frame3: "!"]

Before fix: UI shows ["hello"]        -- 2 messages lost
After fix:  UI shows ["hello", "world", "!"]  -- all messages captured
```

## Fix

Three changes in `lib/network/http/websocket.dart`:

1. **`ByteBuffer.removeBytes(int count)`** -- removes only the first `count` bytes instead of clearing the entire buffer
2. **`_tryFrameLength(Uint8List data)`** -- replaces the old `canParseWebSocketFrame()` + a separate `_frameLength()` method. Returns the exact byte length of the next frame, or null if the data is incomplete or contains an invalid opcode. This eliminates code duplication between the old two methods.
3. **`decode()` method** -- uses `_tryFrameLength()` to get the frame length, then calls `buffer.removeBytes(frameLen)` so remaining frames stay in the buffer

```dart
// Before:
if (!canParseWebSocketFrame(buffer.bytes)) return null;
WebSocketFrame frame = _parseWebSocketFrame(buffer.bytes);
buffer.clear();

// After:
int? frameLen = _tryFrameLength(buffer.bytes);
if (frameLen == null) return null;
WebSocketFrame frame = _parseWebSocketFrame(buffer.bytes);
buffer.removeBytes(frameLen);
```

## Testing

- Existing `websocket_persistence_test.dart` passes (persistence logic unchanged)
- The fix only affects the decoder buffer management, not frame parsing or serialization
