### PR TITLE
fix(search): 支持搜索 WebSocket 消息内容 (#726)

### DIFF
--- a/lib/ui/component/model/search_model.dart
+++ b/lib/ui/component/model/search_model.dart
@@ -214,11 +214,27 @@ class SearchModel {
       return true;
     }
 
-    if (option == Option.requestBody && matches(request.bodyAsString)) {
-      return true;
+    if (option == Option.requestBody) {
+      if (matches(request.bodyAsString)) {
+        return true;
+      }
+      // 仅在用户明确勾选了 WS 协议筛选时才扫描 WebSocket/SSE 等流式消息帧，避免大连接搜索卡顿
+      if (protocols.contains(Protocol.ws) &&
+          request.messages.isNotEmpty &&
+          request.messages.any((m) => matches(m.payloadDataAsString))) {
+        return true;
+      }
     }
-    if (option == Option.responseBody && response != null && matches(response.bodyAsString)) {
-      return true;
+    if (option == Option.responseBody && response != null) {
+      if (matches(response.bodyAsString)) {
+        return true;
+      }
+      // 仅在用户明确勾选了 WS 协议筛选时才扫描 WebSocket/SSE 等流式消息帧，避免大连接搜索卡顿
+      if (protocols.contains(Protocol.ws) &&
+          response.messages.isNotEmpty &&
+          response.messages.any((m) => matches(m.payloadDataAsString))) {
+        return true;
+      }
     }
 
     if (option == Option.requestHeader || option == Option.responseHeader) {


### PR DESCRIPTION
## 背景

Issue #726 反馈：搜索功能无法搜到 WebSocket 消息里的内容。

原因是 `SearchModel.keywordFilter` 中 `Option.requestBody` / `Option.responseBody` 只匹配 `request.bodyAsString` / `response.bodyAsString`，而 WebSocket 帧内容存放在 `HttpRequest.messages` / `HttpResponse.messages`（`WebSocketFrame` 列表），从未被扫描。

## 改动

在 `lib/ui/component/model/search_model.dart` 中，将 body 分支扩展为：先按原逻辑匹配 body，如果**用户在协议筛选中勾选了 `Protocol.ws`**，再遍历 `messages` 并对 `payloadDataAsString` 做匹配。

```dart
if (option == Option.requestBody) {
  if (matches(request.bodyAsString)) return true;
  if (protocols.contains(Protocol.ws) &&
      request.messages.isNotEmpty &&
      request.messages.any((m) => matches(m.payloadDataAsString))) {
    return true;
  }
}
```

`responseBody` 同样处理。

## 为什么加 `protocols.contains(Protocol.ws)` 这个前置条件

WebSocket 连接的 `messages` 可能非常大（几千帧，单帧几十 KB），且每次访问 `payloadDataAsString` 都会重新做 UTF-8 解码。如果无条件遍历，会明显拖慢默认列表搜索的响应速度。

把开关绑定到"WS 协议筛选"上，有几个好处：
- **默认场景零开销**：不勾 WS 时行为与旧版本完全一致。
- **语义自洽**：用户想搜 WebSocket 内容，本来就应该勾 WS 协议 —— 这也是筛选面板里现有的选项，不新增 UI。
- **遍历量可控**：勾了 WS 后，结果集已被限定为 WS 连接，天然裁剪了工作量。

## 使用姿势

1. 打开搜索面板，协议筛选勾 **WS**
2. 搜索范围勾 **请求体** 或 **响应体**
3. 输入关键字

Fixes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)