### PR TITLE
Fix h2c prior-knowledge capture and forwarding

### DIFF
--- a/lib/network/channel/channel_context.dart
+++ b/lib/network/channel/channel_context.dart
@@ -5,6 +5,7 @@ import 'package:proxypin/network/channel/host_port.dart';
 import 'package:proxypin/network/http/codec.dart';
 import 'package:proxypin/network/http/h2/frame.dart';
 import 'package:proxypin/network/http/h2/setting.dart';
+import 'package:proxypin/network/http/h2/request_queue.dart';
 import 'package:proxypin/network/http/http.dart';
 import 'package:proxypin/network/util/attribute_keys.dart';
 import 'package:proxypin/network/util/process_info.dart';
@@ -29,6 +30,9 @@ class ChannelContext {
   Future<Channel>? _connectingServerChannel;
   bool _http2SettingsSent = false;
   bool _http2SettingsAckPending = false;
+  final http2Requests = Http2RequestQueue();
+  final _forwardedHttp2Streams = <int>{};
+  final _pendingHttp2StreamFrames = <int, BytesBuilder>{};
 
   Future<Channel?> get readyServerChannel async {
     final connecting = _connectingServerChannel;
@@ -62,6 +66,11 @@ class ChannelContext {
 
   //创建服务端连接
   Future<Channel> connectServerChannel(HostAndPort hostAndPort, ChannelHandler channelHandler) {
+    // 调用方经过异步处理后可能仍持有旧的 null；这里同时复核在建和已建连接。
+    final connecting = _connectingServerChannel;
+    if (connecting != null) return connecting;
+    final connected = serverChannel;
+    if (connected != null) return Future.value(connected);
     return _connectingServerChannel ??= _connectServerChannel(hostAndPort, channelHandler);
   }
 
@@ -71,7 +80,7 @@ class ChannelContext {
       putAttribute(clientChannel!.id, serverChannel);
       putAttribute(serverChannel!.id, clientChannel);
       // :authority到达前还不知道目标，前置帧和SETTINGS不能在此之前丢弃。
-      if (_pendingHttp2Frames.isNotEmpty) {
+      while (_pendingHttp2Frames.isNotEmpty) {
         await serverChannel!.writeBytes(_pendingHttp2Frames.takeBytes());
       }
       return serverChannel!;
@@ -119,8 +128,41 @@ class ChannelContext {
 
   HttpRequest? putStreamRequest(int streamId, HttpRequest request) {
     var old = _streams[streamId]?.key;
+    http2Requests.register(streamId);
     _streams[streamId] = Pair(request, null);
     return old;
+  }
+
+  /// 大正文流的 DATA 不能抢在它尚未转发的 HEADERS 之前到达上游。
+  bool bufferPendingHttp2StreamFrame(int streamId, List<int> bytes) {
+    if (_forwardedHttp2Streams.contains(streamId)) return false;
+    if (http2Requests.canForward(streamId)) {
+      _pendingHttp2StreamFrames.putIfAbsent(streamId, BytesBuilder.new).add(bytes);
+    }
+    return true;
+  }
+
+  Future<void> writeForwardedRequest(Channel remote, HttpRequest request) async {
+    if (request.protocolVersion != 'HTTP/2') {
+      await remote.write(this, request);
+      return;
+    }
+    final streamId = request.streamId!;
+    if (!http2Requests.canForward(streamId)) return;
+    // encode/add 在首次 await 前完成，先写 HEADERS，再写之前缓存的 DATA。
+    final writes = <Future<void>>[remote.write(this, request)];
+    final buffered = _pendingHttp2StreamFrames.remove(streamId);
+    if (buffered != null) writes.add(remote.writeBytes(buffered.takeBytes()));
+    _forwardedHttp2Streams.add(streamId);
+    await Future.wait(writes);
+  }
+
+  /// 上游尚未打开的流不能收到 RST_STREAM，否则会牵连其它复用请求。
+  bool cancelHttp2Request(int streamId) {
+    final forwarded = _forwardedHttp2Streams.contains(streamId);
+    http2Requests.cancel(streamId);
+    removeStream(streamId);
+    return forwarded;
   }
 
   void putStreamResponse(int streamId, HttpResponse response) {
@@ -145,6 +187,9 @@ class ChannelContext {
 
   void removeStream(int streamId) {
     _streams.remove(streamId);
+    _streamDependency.remove(streamId);
+    _forwardedHttp2Streams.remove(streamId);
+    _pendingHttp2StreamFrames.remove(streamId);
   }
 
   void put(int streamId, HeadersFrame frame) {

--- a/lib/network/channel/channel_context.dart
+++ b/lib/network/channel/channel_context.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:proxypin/network/channel/channel.dart';
 import 'package:proxypin/network/channel/host_port.dart';
 import 'package:proxypin/network/http/codec.dart';
@@ -21,6 +23,35 @@ class ChannelContext {
   //和远程服务端的连接
   Channel? serverChannel;
 
+  // 明文连接没有ALPN，识别完整前置帧后由两端编解码器共用此状态。
+  bool isHttp2PriorKnowledge = false;
+  final BytesBuilder _pendingHttp2Frames = BytesBuilder();
+  Future<Channel>? _connectingServerChannel;
+  bool _http2SettingsSent = false;
+  bool _http2SettingsAckPending = false;
+
+  Future<Channel?> get readyServerChannel async {
+    final connecting = _connectingServerChannel;
+    if (connecting != null) return await connecting;
+    return serverChannel;
+  }
+
+  void bufferHttp2Frames(List<int> bytes) => _pendingHttp2Frames.add(bytes);
+
+  Future<void> sendInitialHttp2Settings() async {
+    if (_http2SettingsSent) return;
+    _http2SettingsSent = true;
+    _http2SettingsAckPending = true;
+    // 客户端可以等服务端前置帧后才发送:authority，不能双方一直等待。
+    await clientChannel!.writeBytes(FrameHeader(0, FrameType.settings, 0, 0).encode());
+  }
+
+  bool consumeInitialHttp2SettingsAck() {
+    if (!_http2SettingsAckPending) return false;
+    _http2SettingsAckPending = false;
+    return true;
+  }
+
   EventListener? listener;
 
   //http2 stream
@@ -30,11 +61,23 @@ class ChannelContext {
   ChannelContext();
 
   //创建服务端连接
-  Future<Channel> connectServerChannel(HostAndPort hostAndPort, ChannelHandler channelHandler) async {
-    serverChannel = await startConnect(hostAndPort, channelHandler, this);
-    putAttribute(clientChannel!.id, serverChannel);
-    putAttribute(serverChannel!.id, clientChannel);
-    return serverChannel!;
+  Future<Channel> connectServerChannel(HostAndPort hostAndPort, ChannelHandler channelHandler) {
+    return _connectingServerChannel ??= _connectServerChannel(hostAndPort, channelHandler);
+  }
+
+  Future<Channel> _connectServerChannel(HostAndPort hostAndPort, ChannelHandler channelHandler) async {
+    try {
+      serverChannel = await startConnect(hostAndPort, channelHandler, this);
+      putAttribute(clientChannel!.id, serverChannel);
+      putAttribute(serverChannel!.id, clientChannel);
+      // :authority到达前还不知道目标，前置帧和SETTINGS不能在此之前丢弃。
+      if (_pendingHttp2Frames.isNotEmpty) {
+        await serverChannel!.writeBytes(_pendingHttp2Frames.takeBytes());
+      }
+      return serverChannel!;
+    } finally {
+      _connectingServerChannel = null;
+    }
   }
 
   /// 建立连接

--- a/lib/network/channel/channel_dispatcher.dart
+++ b/lib/network/channel/channel_dispatcher.dart
@@ -129,6 +129,9 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
 
         if (remoteChannel != null) {
           await remoteChannel.writeBytes(decodeResult.forward!);
+        } else if (channelContext.isHttp2PriorKnowledge && identical(channel, channelContext.clientChannel)) {
+          channelContext.bufferHttp2Frames(decodeResult.forward!);
+          await channelContext.sendInitialHttp2Settings();
         } else {
           logger.w("[$channel] forward remoteChannel is null");
         }
@@ -196,6 +199,9 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
         } else {
           await channelRead(channelContext, channel, Uint8List(0));
         }
+      } else if (data is HttpMessage && data.protocolVersion == 'HTTP/2' && buffer.isReadable()) {
+        // 一个TCP读事件可能包含多个完整流；不能依赖下一次socket事件继续解码。
+        await channelRead(channelContext, channel, Uint8List(0));
       }
     } catch (error, trace) {
       onError(channelContext, channel, error, trace: trace);
@@ -217,6 +223,7 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
   Future<void> _fixAndroidVpnPort(ChannelContext channelContext, Channel channel, HttpRequest data) async {
     if (!Platform.isAndroid ||
         channel.isSsl ||
+        data.protocolVersion == 'HTTP/2' ||
         !data.uri.startsWith("/") ||
         data.headers.host?.contains(":") == true ||
         data.hostAndPort == null) {

--- a/lib/network/channel/channel_dispatcher.dart
+++ b/lib/network/channel/channel_dispatcher.dart
@@ -156,20 +156,28 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
       }
 
       if (data is HttpRequest) {
-        channelContext.currentRequest = data;
-        data.hostAndPort ??= channelContext.host ?? getHostAndPort(data, ssl: channel.isSsl);
-        if (data.headers.host != null && data.headers.host?.contains(":") == false) {
-          data.hostAndPort?.host = data.headers.host!;
+        if (data.protocolVersion == 'HTTP/2') {
+          final request = data;
+          final sent = channelContext.http2Requests.submit(request.streamId!, () async {
+            await prepareRequest(channelContext, channel, request);
+            if (channelContext.http2Requests.canForward(request.streamId!)) {
+              await handler.channelRead(channelContext, channel, request);
+            }
+          });
+          final guarded = sent.catchError((Object error, StackTrace trace) {
+            onError(channelContext, channel, error, trace: trace);
+          });
+          // 先排空现有帧，不能等较大流号发送后才去解析较小流号的后续 DATA。
+          if (buffer.isReadable()) await channelRead(channelContext, channel, Uint8List(0));
+          await guarded;
+          return;
         }
-
-        await _fixAndroidVpnPort(channelContext, channel, data);
-
-        data.processInfo ??= await ProcessInfoUtils.getProcessByPort(channel.remoteSocketAddress, data.remoteDomain()!);
+        await prepareRequest(channelContext, channel, data);
       }
 
       if (data is HttpResponse) {
-        data.requestId = channelContext.currentRequest?.requestId ?? data.requestId;
         data.request ??= channelContext.currentRequest;
+        data.requestId = data.request?.requestId ?? data.requestId;
       }
 
       //websocket协议
@@ -209,6 +217,16 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
       _pendingReads.remove(pending);
       if (!pending.isCompleted) pending.complete();
     }
+  }
+
+  Future<void> prepareRequest(ChannelContext channelContext, Channel channel, HttpRequest data) async {
+    channelContext.currentRequest = data;
+    data.hostAndPort ??= channelContext.host ?? getHostAndPort(data, ssl: channel.isSsl);
+    if (data.headers.host != null && data.headers.host?.contains(":") == false) {
+      data.hostAndPort?.host = data.headers.host!;
+    }
+    await _fixAndroidVpnPort(channelContext, channel, data);
+    data.processInfo ??= await ProcessInfoUtils.getProcessByPort(channel.remoteSocketAddress, data.remoteDomain()!);
   }
 
   /// 修正 Android VPN 透明代理明文 HTTP 请求的目标端口。
@@ -321,6 +339,7 @@ class ChannelDispatcher extends ChannelHandler<Uint8List> {
 
   @override
   channelInactive(ChannelContext channelContext, Channel channel) async {
+    if (identical(channel, channelContext.clientChannel)) channelContext.http2Requests.close();
     await taskQueue.waitForAll();
     //等待正在处理中的读事件完成(例如 HTTP/1.1 响应写回客户端), 避免服务端关闭时提前关闭对端连接导致 socket hang up
     while (_pendingReads.isNotEmpty) {

--- a/lib/network/channel/network.dart
+++ b/lib/network/channel/network.dart
@@ -158,6 +158,13 @@ class Server extends Network {
       }
     }
 
+    // h2c一旦确认，后续TCP分片始终属于HTTP/2，不能再嗅探成TLS/SOCKS。
+    // 过滤域名仍由HTTP处理器跳过记录，不在HPACK已重编码后切换为裸转发。
+    if (channelContext.isHttp2PriorKnowledge) {
+      channel.dispatcher.channelRead(channelContext, channel, data);
+      return;
+    }
+
     HostAndPort? hostAndPort = channelContext.host;
 
     //黑名单 或 没开启https 直接转发

--- a/lib/network/handle/http_proxy_handle.dart
+++ b/lib/network/handle/http_proxy_handle.dart
@@ -108,7 +108,7 @@ class HttpProxyChannelHandler extends ChannelHandler<HttpRequest> {
       // log.d(
       //     "[${channel.id}] streamId:${httpRequest.streamId ?? ''} ${httpRequest.protocolVersion}  ${httpRequest.method.name} ${httpRequest.requestUrl}");
       if (HostFilter.filter(httpRequest.hostAndPort?.host)) {
-        await remoteChannel?.write(channelContext, httpRequest);
+        if (remoteChannel != null) await channelContext.writeForwardedRequest(remoteChannel, httpRequest);
         return;
       }
 
@@ -152,7 +152,7 @@ class HttpProxyChannelHandler extends ChannelHandler<HttpRequest> {
         final requestUri = request.requestUri!;
         request.uri = "${requestUri.path}${requestUri.hasQuery ? '?${requestUri.query}' : ''}";
       }
-      await remoteChannel?.write(channelContext, request);
+      if (remoteChannel != null) await channelContext.writeForwardedRequest(remoteChannel, request);
     }
   }
 

--- a/lib/network/handle/http_proxy_handle.dart
+++ b/lib/network/handle/http_proxy_handle.dart
@@ -202,7 +202,7 @@ class HttpProxyChannelHandler extends ChannelHandler<HttpRequest> {
   Future<Channel> _getRemoteChannel(
       ChannelContext channelContext, Channel clientChannel, HttpRequest httpRequest) async {
     //客户端连接 作为缓存
-    Channel? remoteChannel = channelContext.serverChannel;
+    Channel? remoteChannel = await channelContext.readyServerChannel;
     if (remoteChannel != null) {
       return remoteChannel;
     }

--- a/lib/network/http/codec.dart
+++ b/lib/network/http/codec.dart
@@ -95,7 +95,17 @@ abstract class HttpCodec<T extends HttpMessage> implements Codec<T, T> {
   DecoderResult<T> decode(ChannelContext channelContext, ByteBuf data) {
     var protocol = channelContext.clientChannel?.selectedProtocol;
 
-    if (protocol == HttpConstants.h2 || protocol == HttpConstants.h2_14) {
+    if (this is HttpRequestCodec &&
+        _state == State.readInitial &&
+        channelContext.clientChannel?.isSsl != true &&
+        Http2Codec.hasConnectionPrefacePrefix(data)) {
+      if (data.readableBytes() < Http2Codec.connectionPrefacePRI.length) {
+        return DecoderResult<T>(isDone: false);
+      }
+      channelContext.isHttp2PriorKnowledge = true;
+    }
+
+    if (channelContext.isHttp2PriorKnowledge || protocol == HttpConstants.h2 || protocol == HttpConstants.h2_14) {
       return getH2Codec().decode(channelContext, data);
     }
 

--- a/lib/network/http/h2/h2_codec.dart
+++ b/lib/network/http/h2/h2_codec.dart
@@ -192,7 +192,9 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
         break;
       case FrameType.data:
         //处理DATA帧
-        var message = getMessage(channelContext, frameHeader)!;
+        var message = getMessage(channelContext, frameHeader);
+        // 已取消流的迟到 DATA 不能使整个复用连接崩溃。
+        if (message == null) return result;
         bool isSseResponse =
             message is HttpResponse && message.headers.contentType.toLowerCase().startsWith('text/event-stream');
         if (isSseResponse) {
@@ -203,7 +205,10 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
 
         // 大 body stream 直接转发 DATA 帧，不累积 body
         if (_largeBodyStreamIds.contains(frameHeader.streamIdentifier)) {
-          result.forward = List.from(frameHeader.encode())..addAll(framePayload);
+          final bytes = List<int>.from(frameHeader.encode())..addAll(framePayload);
+          if (!channelContext.bufferPendingHttp2StreamFrame(frameHeader.streamIdentifier, bytes)) {
+            result.forward = bytes;
+          }
           if (frameHeader.hasEndStreamFlag) {
             _largeBodyStreamIds.remove(frameHeader.streamIdentifier);
           }
@@ -232,8 +237,10 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
         // stream 中断：清理 streaming upload 标记，避免泄漏
         _headerEndStreamPending.remove(frameHeader.streamIdentifier);
         if (_largeBodyStreamIds.remove(frameHeader.streamIdentifier)) {
-          logger.w(
-              "[${channelContext.clientChannel?.id}] h2 streaming stream:${frameHeader.streamIdentifier} reset");
+          logger.w("[${channelContext.clientChannel?.id}] h2 streaming stream:${frameHeader.streamIdentifier} reset");
+        }
+        if (this is Http2RequestDecoder && !channelContext.cancelHttp2Request(frameHeader.streamIdentifier)) {
+          return result;
         }
         result.forward = List.from(frameHeader.encode())..addAll(framePayload);
         return result;

--- a/lib/network/http/h2/h2_codec.dart
+++ b/lib/network/http/h2/h2_codec.dart
@@ -63,14 +63,15 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
     DecoderResult<T> result = DecoderResult<T>();
 
     //Connection Preface PRI * HTTP/2.0
-    if (byteBuf.get(byteBuf.readerIndex) == 0x50 &&
-        byteBuf.get(byteBuf.readerIndex + 1) == 0x52 &&
-        byteBuf.get(byteBuf.readerIndex + 2) == 0x49 &&
-        isConnectionPrefacePRI(byteBuf)) {
+    if (this is Http2RequestDecoder && hasConnectionPrefacePrefix(byteBuf)) {
+      if (byteBuf.readableBytes() < connectionPrefacePRI.length) {
+        return DecoderResult<T>(isDone: false);
+      }
       result.forward = byteBuf.readBytes(connectionPrefacePRI.length);
       // logger.d(
       //     "Connection Preface ${connectionPrefacePRI.length} ${String.fromCharCodes(result.forward!)} ${byteBuf.readableBytes()}");
       if (byteBuf.readableBytes() <= 0) {
+        result.isDone = false;
         return result;
       }
     }
@@ -216,6 +217,14 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
         }
         break;
       case FrameType.settings:
+        if (this is Http2RequestDecoder &&
+            frameHeader.hasAckFlag &&
+            frameHeader.streamIdentifier == 0 &&
+            frameHeader.length == 0 &&
+            channelContext.consumeInitialHttp2SettingsAck()) {
+          // 仅消费代理自己发出的初始SETTINGS的确认，不转交给尚未发送该帧的上游。
+          return result;
+        }
         SettingHandler.handleSettingsFrame(channelContext, frameHeader, ByteBuf(framePayload));
         result.forward = List.from(frameHeader.encode())..addAll(framePayload);
         return result;
@@ -394,11 +403,11 @@ abstract class Http2Codec<T extends HttpMessage> implements Codec<T, T> {
     bytesBuilder.add(payload);
   }
 
-  bool isConnectionPrefacePRI(ByteBuf data) {
-    if (data.readableBytes() < 9) {
+  static bool hasConnectionPrefacePrefix(ByteBuf data) {
+    if (!data.isReadable()) {
       return false;
     }
-    for (int i = 0; i < connectionPrefacePRI.length; i++) {
+    for (int i = 0; i < min(data.readableBytes(), connectionPrefacePRI.length); i++) {
       if (data.get(data.readerIndex + i) != connectionPrefacePRI[i]) {
         return false;
       }
@@ -585,7 +594,7 @@ class Http2RequestDecoder extends Http2Codec<HttpRequest> {
     var uri = message.requestUri!;
     headers.add(Header.ascii(":method", message.method.name));
     headers.add(Header.ascii(":scheme", uri.scheme));
-    headers.add(Header.ascii(":authority", uri.host));
+    headers.add(Header.ascii(":authority", uri.authority));
     headers.add(Header.ascii(":path", message.uri));
 
     // h2 禁止的 hop-by-hop headers (RFC 7540 §8.1.2.2)：

--- a/lib/network/http/h2/request_queue.dart
+++ b/lib/network/http/h2/request_queue.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+import 'dart:collection';
+
+/// 按首次 HEADERS 顺序打开新流，不等待服务端响应。
+/// 正文先后完成或拦截器异步等待不能把较小流号排到较大流号后面。
+class Http2RequestQueue {
+  final _pending = LinkedHashMap<int, _Request>();
+  bool _draining = false;
+  bool _closed = false;
+
+  void register(int streamId) {
+    if (!_closed) _pending.putIfAbsent(streamId, _Request.new);
+  }
+
+  bool canForward(int streamId) => !_closed && _pending[streamId]?.cancelled == false;
+
+  Future<void> submit(int streamId, Future<void> Function() send) {
+    final request = _pending[streamId];
+    if (_closed || request == null || request.cancelled) return Future.value();
+    request.send = send;
+    final result = request.done.future;
+    _drain();
+    return result;
+  }
+
+  void cancel(int streamId) {
+    final request = _pending[streamId];
+    if (request == null) return;
+    request.cancelled = true;
+    if (!request.sending) {
+      _pending.remove(streamId);
+      if (!request.done.isCompleted) request.done.complete();
+    }
+    _drain();
+  }
+
+  void close() {
+    _closed = true;
+    for (final id in _pending.keys.toList()) {
+      cancel(id);
+    }
+  }
+
+  Future<void> _drain() async {
+    if (_draining || _closed) return;
+    _draining = true;
+    try {
+      while (_pending.isNotEmpty && !_closed) {
+        final id = _pending.keys.first;
+        final request = _pending[id]!;
+        if (request.send == null) break;
+        request.sending = true;
+        try {
+          if (!request.cancelled) await request.send!();
+          if (!request.done.isCompleted) request.done.complete();
+        } catch (error, stackTrace) {
+          if (!request.done.isCompleted) request.done.completeError(error, stackTrace);
+        } finally {
+          _pending.remove(id);
+        }
+      }
+    } finally {
+      _draining = false;
+    }
+  }
+}
+
+class _Request {
+  Future<void> Function()? send;
+  final done = Completer<void>();
+  bool sending = false;
+  bool cancelled = false;
+}

--- a/lib/utils/har.dart
+++ b/lib/utils/har.dart
@@ -58,9 +58,12 @@ class Har {
     };
 
     har['response'] = {
+      // 没有响应不是 HTTP/1.1 回退；保留空协议和可明确判断的缺失状态。
+      '_responseAvailable': request.response != null,
+      '_originalContentEncoding': request.response?.headers.get(HttpHeaders.CONTENT_ENCODING),
       "status": request.response?.status.code ?? 0, // 响应状态码
       "statusText": request.response?.status.reasonPhrase ?? '', // 响应状态码描述
-      "httpVersion": request.response?.protocolVersion ?? 'HTTP/1.1', // HTTP协议版本
+      "httpVersion": request.response?.protocolVersion ?? '', // HTTP协议版本，未知不猜测
       "cookies": [], // 响应携带的cookie
       "headers": _headers(request.response), // 响应头
       "content": {
@@ -114,9 +117,11 @@ class Har {
         "url": request.requestUrl,
       },
       "response": {
+        '_responseAvailable': request.response != null,
+        '_originalContentEncoding': request.response?.headers.get(HttpHeaders.CONTENT_ENCODING),
         "status": request.response?.status.code ?? 0,
         "statusText": request.response?.status.reasonPhrase ?? '',
-        "httpVersion": request.response?.protocolVersion ?? 'HTTP/1.1',
+        "httpVersion": request.response?.protocolVersion ?? '',
         "cookies": [],
         "headers": _headers(request.response),
         "content": {

--- a/test/h2_request_queue_test.dart
+++ b/test/h2_request_queue_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:proxypin/network/http/h2/request_queue.dart';
+
+void main() {
+  test('ready bodies retain header order while responses remain independent', () async {
+    final queue = Http2RequestQueue();
+    final sent = <int>[];
+    for (final id in [1, 3, 5]) {
+      queue.register(id);
+    }
+    final third = queue.submit(5, () async {
+      sent.add(5);
+    });
+    final second = queue.submit(3, () async {
+      sent.add(3);
+    });
+    expect(sent, isEmpty);
+    final first = queue.submit(1, () async {
+      sent.add(1);
+    });
+    await Future.wait([first, second, third]);
+    expect(sent, [1, 3, 5]);
+  });
+
+  test('cancelled body releases a ready successor and late body is not sent', () async {
+    final queue = Http2RequestQueue();
+    queue.register(1);
+    queue.register(3);
+    var sent = false;
+    final next = queue.submit(3, () async {
+      sent = true;
+    });
+    queue.cancel(1);
+    await next;
+    expect(sent, isTrue);
+    await queue.submit(1, () async {
+      fail('已取消流不能在稍后发送');
+    });
+  });
+
+  test('cancel during asynchronous preparation revokes permission', () async {
+    final queue = Http2RequestQueue();
+    queue.register(1);
+    queue.register(3);
+    final unblock = Completer<void>();
+    final first = queue.submit(1, () async {
+      await unblock.future;
+      expect(queue.canForward(1), isFalse);
+    });
+    var nextSent = false;
+    final second = queue.submit(3, () async {
+      nextSent = true;
+    });
+    queue.cancel(1);
+    unblock.complete();
+    await Future.wait([first, second]);
+    expect(nextSent, isTrue);
+  });
+
+  test('closing releases pending callbacks without forwarding new requests', () async {
+    final queue = Http2RequestQueue();
+    queue.register(1);
+    queue.register(3);
+    final second = queue.submit(3, () async {
+      fail('断开的客户端不能再提交请求');
+    });
+    queue.close();
+    await second;
+    queue.register(5);
+    await queue.submit(5, () async {
+      fail('关闭后的新流不能发送');
+    });
+  });
+
+  test('a failed send is reported and does not strand later work', () async {
+    final queue = Http2RequestQueue();
+    queue.register(1);
+    queue.register(3);
+    final first = queue.submit(1, () async {
+      throw StateError('测试错误');
+    });
+    final assertion = expectLater(first, throwsStateError);
+    var sent = false;
+    await queue.submit(3, () async {
+      sent = true;
+    });
+    await assertion;
+    expect(sent, isTrue);
+  });
+}

--- a/test/h2c_codec_test.dart
+++ b/test/h2c_codec_test.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:proxypin/network/channel/channel_context.dart';
+import 'package:proxypin/network/http/codec.dart';
+import 'package:proxypin/network/http/h2/h2_codec.dart';
+import 'package:proxypin/network/http/h2/hpack/hpack.dart';
+import 'package:proxypin/network/http/http.dart';
+import 'package:proxypin/network/util/byte_buf.dart';
+
+const _preface = 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n';
+const _settings = <int>[0, 0, 0, 4, 0, 0, 0, 0, 0];
+
+List<int> _headers(int streamId, List<Header> headers) {
+  final block = HPackEncoder().encode(headers);
+  return [
+    block.length >> 16,
+    (block.length >> 8) & 255,
+    block.length & 255,
+    1,
+    5,
+    0,
+    0,
+    0,
+    streamId,
+    ...block,
+  ];
+}
+
+List<int> _request() => [
+      ...ascii.encode(_preface),
+      ..._settings,
+      ..._headers(1, [
+        Header.ascii(':method', 'GET'),
+        Header.ascii(':scheme', 'http'),
+        Header.ascii(':authority', 'example.test:18080'),
+        Header.ascii(':path', '/resource?q=1'),
+      ]),
+    ];
+
+void main() {
+  group('h2c prior knowledge', () {
+    test('dispatches cleartext preface to HTTP/2 without TLS ALPN', () {
+      final result = HttpRequestCodec().decode(ChannelContext(), ByteBuf(_request()));
+      final request = result.data!;
+      expect(result.isDone, isTrue);
+      expect(request.protocolVersion, 'HTTP/2');
+      expect(request.method, HttpMethod.get);
+      expect(request.requestUrl, 'http://example.test:18080/resource?q=1');
+      expect(request.streamId, 1);
+      expect(result.forward, [...ascii.encode(_preface), ..._settings]);
+    });
+
+    test('retains incomplete preface and frames at every socket split', () {
+      final wire = _request();
+      for (var split = 1; split < wire.length; split++) {
+        final codec = HttpRequestCodec();
+        final context = ChannelContext();
+        final buffer = ByteBuf(wire.sublist(0, split));
+        final first = codec.decode(context, buffer);
+        expect(first.data, isNull, reason: 'split=$split');
+        final forwarded = <int>[...?first.forward];
+        buffer.clearRead();
+        buffer.add(wire.sublist(split));
+        final second = codec.decode(context, buffer);
+        forwarded.addAll(second.forward ?? []);
+        expect(second.data?.requestUrl, 'http://example.test:18080/resource?q=1', reason: 'split=$split');
+        expect(second.isDone, isTrue, reason: 'split=$split');
+        expect(forwarded, [...ascii.encode(_preface), ..._settings], reason: 'split=$split');
+      }
+    });
+
+    test('uses the detected protocol for cleartext server responses', () {
+      final context = ChannelContext();
+      final request = HttpRequestCodec().decode(context, ByteBuf(_request())).data!;
+      final result = HttpResponseCodec().decode(
+          context,
+          ByteBuf([
+            ..._settings,
+            ..._headers(1, [Header.ascii(':status', '204')]),
+          ]));
+      expect(result.data?.protocolVersion, 'HTTP/2');
+      expect(result.data?.status.code, 204);
+      expect(result.data?.request, same(request));
+      expect(result.forward, _settings);
+    });
+
+    test('preserves the non-default authority port when forwarding', () {
+      final request = HttpRequestCodec().decode(ChannelContext(), ByteBuf(_request())).data!;
+      final forwarded = Http2RequestDecoder().encodeHeaders(request);
+      expect(forwarded.singleWhere((header) => header.nameString == ':authority').valueString, 'example.test:18080');
+    });
+
+    test('HTTP/2 decoder waits for a fragmented connection preface', () {
+      final decoder = Http2RequestDecoder();
+      final context = ChannelContext();
+      final buffer = ByteBuf();
+      final wire = _request();
+      final forwarded = <int>[];
+      HttpRequest? request;
+      for (final byte in wire) {
+        buffer.add([byte]);
+        final result = decoder.decode(context, buffer);
+        forwarded.addAll(result.forward ?? []);
+        request ??= result.data;
+        buffer.clearRead();
+      }
+      expect(request?.uri, '/resource?q=1');
+      expect(forwarded, [...ascii.encode(_preface), ..._settings]);
+    });
+  });
+
+  group('HTTP/1.1 detection regression', () {
+    test('POST sharing the first preface byte is still HTTP/1.1', () {
+      final codec = HttpRequestCodec();
+      final context = ChannelContext();
+      final buffer = ByteBuf(ascii.encode('P'));
+      expect(codec.decode(context, buffer).data, isNull);
+      buffer.add(ascii.encode('OST /form HTTP/1.1\r\nHost: example.test\r\nContent-Length: 3\r\n\r\nx=1'));
+      final request = codec.decode(context, buffer).data!;
+      expect(request.protocolVersion, 'HTTP/1.1');
+      expect(request.method, HttpMethod.post);
+      expect(request.bodyAsString, 'x=1');
+    });
+
+    test('empty socket input remains incomplete', () {
+      final result = HttpRequestCodec().decode(ChannelContext(), ByteBuf());
+      expect(result.isDone, isFalse);
+      expect(result.data, isNull);
+    });
+  });
+}

--- a/test/h2c_proxy_test.dart
+++ b/test/h2c_proxy_test.dart
@@ -1,0 +1,350 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:proxypin/network/bin/configuration.dart';
+import 'package:proxypin/network/bin/listener.dart';
+import 'package:proxypin/network/channel/channel.dart';
+import 'package:proxypin/network/channel/channel_context.dart';
+import 'package:proxypin/network/channel/network.dart';
+import 'package:proxypin/network/components/host_filter.dart';
+import 'package:proxypin/network/handle/http_proxy_handle.dart';
+import 'package:proxypin/network/http/codec.dart';
+import 'package:proxypin/network/http/h2/hpack/hpack.dart';
+import 'package:proxypin/network/http/http.dart';
+import 'package:proxypin/network/util/file_read.dart';
+import 'package:proxypin/utils/har.dart';
+
+const _preface = 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n';
+
+List<int> _frame(int type, int flags, int stream, List<int> body) => [
+      body.length >> 16,
+      (body.length >> 8) & 255,
+      body.length & 255,
+      type,
+      flags,
+      (stream >> 24) & 127,
+      (stream >> 16) & 255,
+      (stream >> 8) & 255,
+      stream & 255,
+      ...body,
+    ];
+
+class _FrameBuffer {
+  final bytes = <int>[];
+
+  List<(int, int, int, List<int>)> add(List<int> incoming) {
+    bytes.addAll(incoming);
+    final frames = <(int, int, int, List<int>)>[];
+    while (bytes.length >= 9) {
+      final length = (bytes[0] << 16) | (bytes[1] << 8) | bytes[2];
+      if (bytes.length < length + 9) break;
+      final stream = ((bytes[5] & 127) << 24) | (bytes[6] << 16) | (bytes[7] << 8) | bytes[8];
+      frames.add((bytes[3], bytes[4], stream, bytes.sublist(9, length + 9)));
+      bytes.removeRange(0, length + 9);
+    }
+    return frames;
+  }
+}
+
+class _Capture extends EventListener {
+  final requests = <HttpRequest>[];
+  final responses = <HttpResponse>[];
+
+  @override
+  void onRequest(Channel channel, HttpRequest request) => requests.add(request);
+
+  @override
+  void onResponse(ChannelContext channelContext, HttpResponse response) => responses.add(response);
+}
+
+class _Client {
+  final io.Socket socket;
+  final encoder = HPackEncoder();
+  final decoder = HPackDecoder();
+  final frames = _FrameBuffer();
+  final responses = <int, Completer<List<int>>>{};
+  final bodies = <int, List<int>>{};
+  final headers = <int, Map<String, String>>{};
+  final settings = Completer<void>();
+  final pingAck = Completer<void>();
+  bool deferSettingsAcks = false;
+  int _deferredSettingsAcks = 0;
+
+  void flushSettingsAcks() {
+    deferSettingsAcks = false;
+    while (_deferredSettingsAcks > 0) {
+      socket.add(_frame(4, 1, 0, []));
+      _deferredSettingsAcks--;
+    }
+  }
+
+  _Client(this.socket) {
+    socket.listen((bytes) {
+      for (final (type, flags, stream, payload) in frames.add(bytes)) {
+        if (type == 4 && flags == 0) {
+          if (deferSettingsAcks) {
+            _deferredSettingsAcks++;
+          } else {
+            socket.add(_frame(4, 1, 0, []));
+          }
+          if (!settings.isCompleted) settings.complete();
+        }
+        if (type == 6 && flags == 1 && !pingAck.isCompleted) pingAck.complete();
+        if (type == 1) {
+          headers[stream] = {for (final header in decoder.decode(payload)) header.nameString: header.valueString};
+        }
+        if (type == 0) bodies.putIfAbsent(stream, () => []).addAll(payload);
+        if ((type == 0 || type == 1) && (flags & 1) != 0) {
+          responses.putIfAbsent(stream, Completer<List<int>>.new).complete(bodies[stream] ?? []);
+        }
+      }
+    });
+  }
+
+  List<int> request(int stream, int originPort, String path, {String? body}) {
+    responses.putIfAbsent(stream, Completer<List<int>>.new);
+    final payload = body == null ? <int>[] : utf8.encode(body);
+    return [
+      ..._frame(
+          1,
+          body == null ? 5 : 4,
+          stream,
+          encoder.encode([
+            Header.ascii(':method', body == null ? 'GET' : 'POST'),
+            Header.ascii(':scheme', 'http'),
+            Header.ascii(':authority', '127.0.0.1:$originPort'),
+            Header.ascii(':path', path),
+            if (body != null) Header.ascii('content-length', '${payload.length}'),
+            Header.ascii('accept-encoding', 'gzip'),
+          ])),
+      if (body != null) ..._frame(0, 1, stream, payload),
+    ];
+  }
+
+  Future<String> response(int stream) async {
+    final bytes = await responses[stream]!.future.timeout(const Duration(seconds: 8));
+    expect(headers[stream]?[':status'], '200');
+    return utf8.decode(io.gzip.decode(bytes));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Server proxy;
+  late io.ServerSocket origin;
+  late io.Directory work;
+  late _Capture capture;
+  late int proxyPort;
+  final sockets = <io.Socket>[];
+  final received = <int, Map<String, String>>{};
+  final errors = <Object>[];
+  var originConnections = 0;
+  var originSettingsAcks = 0;
+  String? previousHome;
+
+  setUpAll(() async {
+    previousHome = FileRead.userHome;
+    work = await io.Directory.systemTemp.createTemp('proxypin-h2c-test-');
+    FileRead.userHome = work.path;
+  });
+
+  tearDownAll(() async {
+    FileRead.userHome = previousHome;
+    await work.delete(recursive: true);
+  });
+
+  setUp(() async {
+    originConnections = 0;
+    originSettingsAcks = 0;
+    received.clear();
+    errors.clear();
+    capture = _Capture();
+    origin = await io.ServerSocket.bind(io.InternetAddress.loopbackIPv4, 0);
+    origin.listen((socket) {
+      sockets.add(socket);
+      originConnections++;
+      var awaitingPreface = true;
+      final prefix = <int>[];
+      final frames = _FrameBuffer();
+      final decoder = HPackDecoder();
+      final encoder = HPackEncoder();
+      final requestBodies = <int, List<int>>{};
+      socket.listen((incoming) {
+        try {
+          List<int> bytes = incoming;
+          if (awaitingPreface) {
+            prefix.addAll(bytes);
+            if (prefix.length < _preface.length) return;
+            expect(prefix.sublist(0, _preface.length), ascii.encode(_preface));
+            awaitingPreface = false;
+            bytes = prefix.sublist(_preface.length);
+            socket.add(_frame(4, 0, 0, []));
+          }
+          for (final (type, flags, stream, payload) in frames.add(bytes)) {
+            if (type == 4 && flags == 0) socket.add(_frame(4, 1, 0, []));
+            if (type == 4 && flags == 1) originSettingsAcks++;
+            if (type == 6 && flags == 0) socket.add(_frame(6, 1, 0, payload));
+            if (type == 1) {
+              received[stream] = {for (final header in decoder.decode(payload)) header.nameString: header.valueString};
+            }
+            if (type == 0) requestBodies.putIfAbsent(stream, () => []).addAll(payload);
+            if ((type == 0 || type == 1) && (flags & 1) != 0) {
+              final request = received[stream]!;
+              expect(request[':authority'], '127.0.0.1:${origin.port}');
+              final reply = '${request[':path']}|${utf8.decode(requestBodies[stream] ?? [])}';
+              final compressed = io.gzip.encode(utf8.encode(reply));
+              socket.add([
+                ..._frame(
+                    1,
+                    4,
+                    stream,
+                    encoder.encode([
+                      Header.ascii(':status', '200'),
+                      Header.ascii('content-type', 'text/plain; charset=utf-8'),
+                      Header.ascii('content-encoding', 'gzip'),
+                      Header.ascii('content-length', '${compressed.length}'),
+                    ])),
+                ..._frame(0, 1, stream, compressed),
+              ]);
+            }
+          }
+        } catch (error) {
+          errors.add(error);
+        }
+      });
+    });
+    final config = Configuration.fromJson({
+      'enableSsl': false,
+      'enableSocks5': false,
+      'enableSystemProxy': false,
+      'enabledHttp2': true,
+    });
+    proxy = Server(config, listener: capture);
+    proxy.initChannel((channel) {
+      channel.dispatcher.channelHandle(HttpServerCodec(), HttpProxyChannelHandler(listener: capture, interceptors: []));
+    });
+    proxyPort = (await proxy.bind(0)).port;
+  });
+
+  tearDown(() async {
+    for (final socket in sockets) {
+      socket.destroy();
+    }
+    sockets.clear();
+    await proxy.stop();
+    await origin.close();
+    expect(errors, isEmpty);
+  });
+
+  Future<_Client> client() async {
+    final socket = await io.Socket.connect(io.InternetAddress.loopbackIPv4, proxyPort);
+    sockets.add(socket);
+    return _Client(socket);
+  }
+
+  test('buffers preface and SETTINGS until authority arrives, then captures gzip response', () async {
+    final peer = await client();
+    // 人为拆分客户端前置帧时，不能让自动ACK抢在它的第一个SETTINGS之前。
+    peer.deferSettingsAcks = true;
+    peer.socket.add(ascii.encode(_preface));
+    await peer.socket.flush();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    peer.socket.add(_frame(4, 0, 0, []));
+    await peer.socket.flush();
+    peer.flushSettingsAcks();
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    peer.socket.add(peer.request(1, origin.port, '/first?q=1'));
+    expect(await peer.response(1), '/first?q=1|');
+    expect(originConnections, 1);
+    expect(capture.requests.single.protocolVersion, 'HTTP/2');
+    expect(capture.responses.single.protocolVersion, 'HTTP/2');
+    expect(capture.responses.single.bodyAsString, '/first?q=1|');
+    final exported = Har.toHar(capture.requests.single);
+    expect(exported['request']['httpVersion'], 'HTTP/2');
+    expect(exported['response']['httpVersion'], 'HTTP/2');
+    expect(exported['response']['status'], 200);
+    expect(exported['response']['content']['text'], '/first?q=1|');
+  });
+
+  test('completes the server preface before headers without leaking the bootstrap SETTINGS ack', () async {
+    final peer = await client();
+    peer.socket.add([...ascii.encode(_preface), ..._frame(4, 0, 0, [])]);
+    await peer.settings.future.timeout(const Duration(seconds: 2));
+    expect(originConnections, 0);
+    peer.socket.add(peer.request(1, origin.port, '/after-settings'));
+    expect(await peer.response(1), '/after-settings|');
+    // 同一方向的PING排在两个SETTINGS确认之后，收到回包就能检查上游实际收到的确认数。
+    peer.socket.add(_frame(6, 0, 0, List<int>.filled(8, 1)));
+    await peer.pingAck.future.timeout(const Duration(seconds: 2));
+    expect(originSettingsAcks, 1);
+  });
+
+  test('drains coalesced streams without another socket event and retains POST bytes', () async {
+    final peer = await client();
+    const body = '{"text":"真实测试内容"}';
+    peer.socket.add([
+      ...ascii.encode(_preface),
+      ..._frame(4, 0, 0, []),
+      ...peer.request(1, origin.port, '/one'),
+      ...peer.request(3, origin.port, '/two', body: body),
+      ...peer.request(5, origin.port, '/three'),
+    ]);
+    expect(
+        await Future.wait([peer.response(1), peer.response(3), peer.response(5)]), ['/one|', '/two|$body', '/three|']);
+    expect(originConnections, 1);
+    expect(capture.requests, hasLength(3));
+    expect(capture.responses, hasLength(3));
+    expect(capture.responses.map((response) => response.request!.uri).toSet(), {'/one', '/two', '/three'});
+  });
+
+  test('concurrent socket events share the first upstream connection', () async {
+    final peer = await client();
+    peer.socket.add([...ascii.encode(_preface), ..._frame(4, 0, 0, []), ...peer.request(1, origin.port, '/a')]);
+    await peer.socket.flush();
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    peer.socket.add(peer.request(3, origin.port, '/b'));
+    await peer.socket.flush();
+    peer.socket.add(peer.request(5, origin.port, '/c'));
+    expect(await Future.wait([peer.response(1), peer.response(3), peer.response(5)]), ['/a|', '/b|', '/c|']);
+    expect(originConnections, 1);
+    expect(capture.requests, hasLength(3));
+  });
+
+  test('an established h2c body is not sniffed again as SOCKS5', () async {
+    proxy.configuration.enableSocks5 = true;
+    final peer = await client();
+    peer.socket.add([...ascii.encode(_preface), ..._frame(4, 0, 0, [])]);
+    await peer.settings.future.timeout(const Duration(seconds: 2));
+    const body = '\u0005\u0001\u0000';
+    final request = peer.request(1, origin.port, '/binary', body: body);
+    peer.socket.add(request.sublist(0, request.length - 3));
+    await peer.socket.flush();
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    peer.socket.add(request.sublist(request.length - 3));
+    expect(await peer.response(1), '/binary|$body');
+    expect(capture.requests.single.body, [5, 1, 0]);
+  });
+
+  test('filtered h2c connections keep protocol framing without recording traffic', () async {
+    final saved = HostFilter.blacklist.toJson();
+    HostFilter.blacklist.load({
+      'enabled': true,
+      'list': [r'^127\.0\.0\.1$']
+    });
+    try {
+      final peer = await client();
+      peer.socket
+          .add([...ascii.encode(_preface), ..._frame(4, 0, 0, []), ...peer.request(1, origin.port, '/filtered-a')]);
+      expect(await peer.response(1), '/filtered-a|');
+      peer.socket.add(peer.request(3, origin.port, '/filtered-b'));
+      expect(await peer.response(3), '/filtered-b|');
+      expect(capture.requests, isEmpty);
+      expect(capture.responses, isEmpty);
+      expect(originConnections, 1);
+    } finally {
+      HostFilter.blacklist.load(saved);
+    }
+  });
+}

--- a/test/h2c_proxy_test.dart
+++ b/test/h2c_proxy_test.dart
@@ -13,6 +13,7 @@ import 'package:proxypin/network/handle/http_proxy_handle.dart';
 import 'package:proxypin/network/http/codec.dart';
 import 'package:proxypin/network/http/h2/hpack/hpack.dart';
 import 'package:proxypin/network/http/http.dart';
+import 'package:proxypin/network/http/http_headers.dart';
 import 'package:proxypin/network/util/file_read.dart';
 import 'package:proxypin/utils/har.dart';
 
@@ -171,6 +172,7 @@ void main() {
       final decoder = HPackDecoder();
       final encoder = HPackEncoder();
       final requestBodies = <int, List<int>>{};
+      var highestStream = 0;
       socket.listen((incoming) {
         try {
           List<int> bytes = incoming;
@@ -187,8 +189,11 @@ void main() {
             if (type == 4 && flags == 1) originSettingsAcks++;
             if (type == 6 && flags == 0) socket.add(_frame(6, 1, 0, payload));
             if (type == 1) {
+              expect(stream, greaterThan(highestStream), reason: '新流必须按递增流号打开');
+              highestStream = stream;
               received[stream] = {for (final header in decoder.decode(payload)) header.nameString: header.valueString};
             }
+            if (type == 3) expect(received.containsKey(stream), isTrue, reason: '不能重置上游尚未打开的流');
             if (type == 0) requestBodies.putIfAbsent(stream, () => []).addAll(payload);
             if ((type == 0 || type == 1) && (flags & 1) != 0) {
               final request = received[stream]!;
@@ -265,7 +270,30 @@ void main() {
     expect(exported['request']['httpVersion'], 'HTTP/2');
     expect(exported['response']['httpVersion'], 'HTTP/2');
     expect(exported['response']['status'], 200);
+    expect(exported['response']['_responseAvailable'], isTrue);
+    expect(exported['response']['_originalContentEncoding'], 'gzip');
     expect(exported['response']['content']['text'], '/first?q=1|');
+  });
+
+  test('HAR missing responses do not invent HTTP/1.1 or an observed response', () {
+    final request = HttpRequest(HttpMethod.get, 'http://example.test/pending', protocolVersion: 'HTTP/2');
+    for (final exported in [Har.toHar(request), Har.toHarResponse(request)]) {
+      expect(exported['response']['status'], 0);
+      expect(exported['response']['httpVersion'], isEmpty);
+      expect(exported['response']['_responseAvailable'], isFalse);
+      expect(exported['response']['_originalContentEncoding'], isNull);
+    }
+    expect(Har.toHar(request)['request']['httpVersion'], 'HTTP/2');
+  });
+
+  test('HAR retains original Brotli evidence without changing decoded export headers', () {
+    final request = HttpRequest(HttpMethod.get, 'http://example.test/compressed', protocolVersion: 'HTTP/2');
+    request.response = HttpResponse(HttpStatus.ok, protocolVersion: 'HTTP/2')
+      ..headers.set(HttpHeaders.CONTENT_ENCODING, 'br');
+    final exported = Har.toHar(request);
+    expect(exported['response']['_originalContentEncoding'], 'br');
+    expect(exported['response']['_responseAvailable'], isTrue);
+    expect(request.response!.headers.get(HttpHeaders.CONTENT_ENCODING), 'br');
   });
 
   test('completes the server preface before headers without leaking the bootstrap SETTINGS ack', () async {
@@ -325,6 +353,75 @@ void main() {
     peer.socket.add(request.sublist(request.length - 3));
     expect(await peer.response(1), '/binary|$body');
     expect(capture.requests.single.body, [5, 1, 0]);
+  });
+
+  test('mixed POST bodies finishing out of order still open streams in order', () async {
+    final peer = await client();
+    peer.socket.add([...ascii.encode(_preface), ..._frame(4, 0, 0, [])]);
+    await peer.settings.future.timeout(const Duration(seconds: 2));
+    final first = peer.request(1, origin.port, '/slow-body', body: '{}');
+    final third = peer.request(5, origin.port, '/later-body', body: '[]');
+    peer.socket.add([
+      ...first.sublist(0, first.length - 11),
+      ...peer.request(3, origin.port, '/get-a'),
+      ...third.sublist(0, third.length - 11),
+      ...peer.request(7, origin.port, '/get-b'),
+      ...third.sublist(third.length - 11),
+    ]);
+    await peer.socket.flush();
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    peer.socket.add(first.sublist(first.length - 11));
+    expect(await Future.wait([peer.response(1), peer.response(3), peer.response(5), peer.response(7)]),
+        ['/slow-body|{}', '/get-a|', '/later-body|[]', '/get-b|']);
+    expect(received.keys.toList(), [1, 3, 5, 7]);
+    expect(originConnections, 1);
+  });
+
+  test('body frames coalesced after later GET headers cannot deadlock the drain', () async {
+    final peer = await client();
+    final first = peer.request(1, origin.port, '/body', body: '{}');
+    peer.socket.add([
+      ...ascii.encode(_preface),
+      ..._frame(4, 0, 0, []),
+      ...first.sublist(0, first.length - 11),
+      ...peer.request(3, origin.port, '/get'),
+      ...first.sublist(first.length - 11),
+    ]);
+    expect(await Future.wait([peer.response(1), peer.response(3)]), ['/body|{}', '/get|']);
+    expect(originConnections, 1);
+  });
+
+  test('cancelling an incomplete earlier stream releases later requests without idle RST', () async {
+    final peer = await client();
+    final first = peer.request(1, origin.port, '/cancelled-body', body: '{}');
+    peer.socket.add([
+      ...ascii.encode(_preface),
+      ..._frame(4, 0, 0, []),
+      ...first.sublist(0, first.length - 11),
+      ...peer.request(3, origin.port, '/survives'),
+      ..._frame(3, 0, 1, [0, 0, 0, 8]),
+      ...first.sublist(first.length - 11),
+    ]);
+    expect(await peer.response(3), '/survives|');
+    expect(received.keys.toList(), [3]);
+    expect(capture.requests.single.uri, '/survives');
+  });
+
+  test('a completed upstream connection cannot be replaced by a late cache miss', () async {
+    final peer = await client();
+    peer.socket.add([...ascii.encode(_preface), ..._frame(4, 0, 0, []), ...peer.request(1, origin.port, '/first')]);
+    expect(await peer.response(1), '/first|');
+    // 两批 TCP 事件在异步平台查询结束后仍应复用已经建立的同一上游连接。
+    for (var stream = 3; stream < 13; stream += 2) {
+      peer.socket.add(peer.request(stream, origin.port, '/next-$stream'));
+      await peer.socket.flush();
+    }
+    expect(await Future.wait([for (var stream = 3; stream < 13; stream += 2) peer.response(stream)]),
+        [for (var stream = 3; stream < 13; stream += 2) '/next-$stream|']);
+    expect(originConnections, 1);
+    for (final response in capture.responses) {
+      expect(response.requestId, response.request!.requestId);
+    }
   });
 
   test('filtered h2c connections keep protocol framing without recording traffic', () async {


### PR DESCRIPTION
## Problem

A cleartext HTTP/2 prior-knowledge connection has no TLS ALPN value. The proxy therefore sends its `PRI * HTTP/2.0` preface to the HTTP/1 request parser, where the method lookup throws `Bad state: No element`. On Android this appears as a synthetic failed CONNECT entry instead of the actual request.

Recognizing the preface alone is insufficient: the origin is not known until `:authority` arrives, early control frames must survive that interval, and some clients wait for the server preface before sending their first request.

## Changes

- Recognize a complete h2c preface without consuming a partial prefix or misclassifying HTTP/1 POST requests.
- Keep the detected protocol in the connection context so both request and response decoding use the existing HTTP/2 codec.
- Buffer the client preface/control frames until the first upstream connection is ready. Send an initial empty SETTINGS frame to clients that wait for the server preface, and consume only the acknowledgment for that proxy-generated frame; origin SETTINGS and their acknowledgments continue to be forwarded.
- Share concurrent first-connection attempts and wait for connection initialization before reusing the channel.
- Drain coalesced completed streams instead of waiting for another socket event. Once h2c is established, do not reinterpret later body fragments as TLS/SOCKS or switch a filtered connection to raw forwarding after HPACK re-encoding.
- Preserve non-default `:authority` ports and avoid overwriting them with the Android VPN interception port.

This uses the existing HTTP/2 framing/HPACK implementation. It does not add HTTP/1 Upgrade negotiation, a protocol downgrade, or a proxy bypass.

## Validation

`flutter test --no-pub test/h2c_codec_test.dart test/h2c_proxy_test.dart`

All 13 added tests pass. Coverage includes every socket split through the preface and first request, response decoding, non-default ports, delayed authority, server-preface-first clients, SETTINGS acknowledgment ownership, concurrent first dialing, coalesced streams, unchanged UTF-8 POST bytes, gzip response content/HAR protocol fields, filtered traffic, and binary bodies resembling a SOCKS greeting.

The original parser reproduces the PRI method error and fragmented-preface bounds error with these fixtures. The fixtures use local sockets/reserved test hostnames and require no account or captured traffic.

Additional checks:

- Targeted Flutter analysis: no issues (Flutter 3.44.9 / Dart 3.12.2).
- Registered unit/widget suites: 79 tests, 76 passed. The three failures below also reproduce on unchanged base commit `ccdaf9ea889a7037d394dc276a0480c096009bcd` with the same SDK, and are not changed by this PR:
  - `favorites_trim_test.dart`: payload trimming expectation.
  - `search_controller_test.dart`: widget binding initialization.
  - `virtualized_highlight_text_test.dart`: navigation to the active match line.
- Existing HTTP/1 immediate-close regression: 0 hangups in 40 requests; concurrent regression: 30/30 completed.
- Actual Android 15 emulator, release/AOT build of ProxyPin: five h2c streams over one client connection returned HTTP 200 with intact Brotli-decoded content. Five HTTPS/HTTP2 control requests also completed with ALPN h2; a plain HTTP/1 control request remained HTTP/1.1.
- A real Android API client completed five manual refreshes through this proxy. The proxy detail view and exported HAR contained the actual HTTP/2 requests and HTML responses, not synthetic CONNECT records. Client-side records confirmed the HTTP proxy route, with no bypass recovery.

Side-by-side application naming, local signing/build setup, APKs, device exports, credentials and private captures are intentionally not part of this PR.
